### PR TITLE
[DUCKLING] Add distinct statuses for review process and update dashboard visual cues

### DIFF
--- a/public/css/base.css
+++ b/public/css/base.css
@@ -1,9 +1,10 @@
 .status-badge {
   @apply inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium;
 }
-.status-pending { @apply bg-yellow-100 text-yellow-800; }
-.status-in-progress { @apply bg-blue-100 text-blue-800; }
-.status-awaiting-review { @apply bg-purple-100 text-purple-800; }
+.status-pending { @apply bg-gray-100 text-gray-800; }
+.status-in-progress { @apply bg-yellow-100 text-yellow-800; }
+.status-addressing-review { @apply bg-yellow-100 text-yellow-800; }
+.status-awaiting-review { @apply bg-blue-100 text-blue-800; }
 .status-completed { @apply bg-green-100 text-green-800; }
 .status-failed { @apply bg-red-100 text-red-800; }
 .status-cancelled { @apply bg-gray-100 text-gray-800; }
@@ -85,6 +86,23 @@
   50% {
     border-color: #f59e0b;
     box-shadow: 0 0 0 4px rgba(251, 191, 36, 0.1);
+  }
+}
+
+/* Pulsing blue border for awaiting review tasks */
+.task-awaiting-review {
+  @apply border-blue-400;
+  animation: pulse-blue 2s ease-in-out infinite;
+}
+
+@keyframes pulse-blue {
+  0%, 100% {
+    border-color: #60a5fa;
+    box-shadow: 0 0 0 2px rgba(96, 165, 250, 0.3);
+  }
+  50% {
+    border-color: #3b82f6;
+    box-shadow: 0 0 0 4px rgba(96, 165, 250, 0.1);
   }
 }
 

--- a/public/js/dashboard.js
+++ b/public/js/dashboard.js
@@ -454,9 +454,13 @@ class Dashboard {
     const canCancel = task.status !== 'completed' && task.status !== 'cancelled' && task.status !== 'failed';
     const canComplete = task.status !== 'completed' && task.status !== 'cancelled' && task.status !== 'failed';
 
-    // Add pulsing border if task is in progress or awaiting review
-    const isWorking = task.status === 'in-progress' || task.status === 'awaiting-review';
-    const borderClass = isWorking ? 'task-working' : '';
+    // Add pulsing border based on status
+    let borderClass = '';
+    if (task.status === 'in-progress' || task.status === 'addressing-review') {
+      borderClass = 'task-working';
+    } else if (task.status === 'awaiting-review') {
+      borderClass = 'task-awaiting-review';
+    }
 
     return `
       <div class="task-card bg-white border border-gray-200 rounded-lg p-6 hover:shadow-sm transition-shadow ${borderClass}" data-task-id="${task.id}">

--- a/public/js/task-detail.js
+++ b/public/js/task-detail.js
@@ -79,8 +79,16 @@ class TaskDetail {
     // Update page title with task summary
     document.title = `Duckling - ${summary}`;
 
+    // Add border class based on status
+    let borderClass = '';
+    if (task.status === 'in-progress' || task.status === 'addressing-review') {
+      borderClass = 'task-working';
+    } else if (task.status === 'awaiting-review') {
+      borderClass = 'task-awaiting-review';
+    }
+
     container.innerHTML = `
-      <div class="bg-white rounded-lg shadow-sm border border-gray-200 p-8">
+      <div class="bg-white rounded-lg shadow-sm border border-gray-200 p-8 ${borderClass}">
         <!-- Header -->
         <div class="flex justify-between items-start mb-6">
           <div class="flex-1">

--- a/public/js/utils.js
+++ b/public/js/utils.js
@@ -24,6 +24,7 @@ window.Utils = {
       'pending': 'Pending',
       'in_progress': 'In Progress',
       'awaiting_review': 'Awaiting Review',
+      'addressing_review': 'Addressing Review',
       'completed': 'Completed',
       'failed': 'Failed',
       'cancelled': 'Cancelled'
@@ -148,6 +149,7 @@ window.Utils = {
     const badges = {
       'pending': 'bg-gray-100 text-gray-800',
       'in-progress': 'bg-yellow-100 text-yellow-800',
+      'addressing-review': 'bg-yellow-100 text-yellow-800',
       'awaiting-review': 'bg-blue-100 text-blue-800',
       'completed': 'bg-green-100 text-green-800',
       'failed': 'bg-red-100 text-red-800',

--- a/src/api/routes.ts
+++ b/src/api/routes.ts
@@ -310,10 +310,7 @@ export function createRoutes(db: DatabaseManager, engine: CoreEngine): Router {
         });
       }
 
-      const logFilePath = pathLib.join(
-        LOGS_DIR,
-        `task-${taskId}.log`
-      );
+      const logFilePath = pathLib.join(LOGS_DIR, `task-${taskId}.log`);
 
       // Check if log file exists
       if (!fs.existsSync(logFilePath)) {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -19,6 +19,7 @@ export type TaskStatus =
   | 'pending'
   | 'in-progress'
   | 'awaiting-review'
+  | 'addressing-review'
   | 'completed'
   | 'failed'
   | 'cancelled';


### PR DESCRIPTION
**Summary**: Introduced separate statuses for "awaiting review" and "addressing review" to improve task clarity. Updated the front-end dashboard and task details page to display these new statuses with distinct border and pill colors: no border for "pending," yellow border for "in progress" and "addressing review," and blue border for "awaiting review."