### PR TITLE
[DUCKLING] Make branch name a link to GitHub in dashboard and task details page

### DIFF
--- a/public/js/dashboard.js
+++ b/public/js/dashboard.js
@@ -439,7 +439,7 @@ class Dashboard {
       '<span class="text-gray-400 text-sm">No PR yet</span>';
 
     const branchName = task.branch_name ?
-      `<span class="text-sm text-gray-600 font-mono">${this.escapeHtml(task.branch_name)}</span>` :
+      this.getBranchLink(task.branch_name, task.repository_path) :
       '<span class="text-gray-400 text-sm">No branch yet</span>';
 
     // Get repository info
@@ -736,6 +736,16 @@ class Dashboard {
 
   escapeHtml(text) {
     return Utils.escapeHtml(text || '');
+  }
+
+  getBranchLink(branchName, repositoryPath) {
+    const repository = this.repositories.find(repo => repo.path === repositoryPath);
+    if (repository && repository.owner && repository.name) {
+      const githubUrl = `https://github.com/${repository.owner}/${repository.name}/tree/${branchName}`;
+      return `<a href="${githubUrl}" target="_blank" class="text-blue-600 text-sm hover:text-blue-800 underline font-mono">${this.escapeHtml(branchName)}</a>`;
+    }
+    // Fallback to plain text if repository info is not available
+    return `<span class="text-sm text-gray-600 font-mono">${this.escapeHtml(branchName)}</span>`;
   }
 
   // Helper method to enable/disable task creation form

--- a/public/js/task-detail.js
+++ b/public/js/task-detail.js
@@ -168,7 +168,7 @@ class TaskDetail {
               ${task.branch_name ? `
                 <div class="flex justify-between">
                   <span class="text-gray-600">Branch:</span>
-                  <span class="font-mono text-sm">${this.escapeHtml(task.branch_name)}</span>
+                  <span>${this.getBranchLink(task.branch_name, task.repository_path)}</span>
                 </div>
               ` : ''}
               ${task.pr_url ? `
@@ -526,6 +526,16 @@ class TaskDetail {
 
   escapeHtml(text) {
     return Utils.escapeHtml(text || '');
+  }
+
+  getBranchLink(branchName, repositoryPath) {
+    const repository = this.repositories.find(repo => repo.path === repositoryPath);
+    if (repository && repository.owner && repository.name) {
+      const githubUrl = `https://github.com/${repository.owner}/${repository.name}/tree/${branchName}`;
+      return `<a href="${githubUrl}" target="_blank" class="text-blue-600 hover:text-blue-800 underline font-mono text-sm">${this.escapeHtml(branchName)}</a>`;
+    }
+    // Fallback to plain text if repository info is not available
+    return `<span class="font-mono text-sm">${this.escapeHtml(branchName)}</span>`;
   }
 
   async loadRepositories() {

--- a/src/api/routes.ts
+++ b/src/api/routes.ts
@@ -310,10 +310,7 @@ export function createRoutes(db: DatabaseManager, engine: CoreEngine): Router {
         });
       }
 
-      const logFilePath = pathLib.join(
-        LOGS_DIR,
-        `task-${taskId}.log`
-      );
+      const logFilePath = pathLib.join(LOGS_DIR, `task-${taskId}.log`);
 
       // Check if log file exists
       if (!fs.existsSync(logFilePath)) {

--- a/test-branch-links.html
+++ b/test-branch-links.html
@@ -1,0 +1,82 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Test Branch Links</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="p-8">
+    <h1 class="text-2xl font-bold mb-4">Test Branch Link Generation</h1>
+    
+    <div id="test-results" class="space-y-4"></div>
+
+    <script src="public/js/utils.js"></script>
+    <script>
+        // Mock Dashboard class for testing
+        class TestDashboard {
+            constructor() {
+                this.repositories = [
+                    { id: 1, path: '/test/repo1', name: 'test-repo', owner: 'testuser' },
+                    { id: 2, path: '/test/repo2', name: 'another-repo', owner: 'anotheruser' }
+                ];
+            }
+
+            getBranchLink(branchName, repositoryPath) {
+                const repository = this.repositories.find(repo => repo.path === repositoryPath);
+                if (repository && repository.owner && repository.name) {
+                    const githubUrl = `https://github.com/${repository.owner}/${repository.name}/tree/${branchName}`;
+                    return `<a href="${githubUrl}" target="_blank" class="text-blue-600 text-sm hover:text-blue-800 underline font-mono">${this.escapeHtml(branchName)}</a>`;
+                }
+                // Fallback to plain text if repository info is not available
+                return `<span class="text-sm text-gray-600 font-mono">${this.escapeHtml(branchName)}</span>`;
+            }
+
+            escapeHtml(text) {
+                return Utils.escapeHtml(text || '');
+            }
+        }
+
+        // Test the functionality
+        const dashboard = new TestDashboard();
+        const testResults = document.getElementById('test-results');
+
+        // Test cases
+        const testCases = [
+            {
+                name: 'Valid repository with branch',
+                branchName: 'duckling-fix-auth',
+                repositoryPath: '/test/repo1',
+                expected: 'Should generate GitHub link'
+            },
+            {
+                name: 'Valid repository with special characters in branch',
+                branchName: 'feature/add-new-feature',
+                repositoryPath: '/test/repo2',
+                expected: 'Should generate GitHub link and escape branch name'
+            },
+            {
+                name: 'Invalid repository path',
+                branchName: 'some-branch',
+                repositoryPath: '/unknown/repo',
+                expected: 'Should fallback to plain text'
+            }
+        ];
+
+        testCases.forEach(test => {
+            const result = dashboard.getBranchLink(test.branchName, test.repositoryPath);
+            
+            const testDiv = document.createElement('div');
+            testDiv.className = 'border p-4 rounded';
+            testDiv.innerHTML = `
+                <h3 class="font-bold">${test.name}</h3>
+                <p class="text-sm text-gray-600 mb-2">${test.expected}</p>
+                <div class="bg-gray-100 p-2 rounded">
+                    Result: ${result}
+                </div>
+            `;
+            testResults.appendChild(testDiv);
+        });
+    </script>
+</body>
+</html>


### PR DESCRIPTION
**Summary**: Updated the dashboard and task details page to convert the branch name into a clickable link leading to the relevant branch on GitHub, mirroring the existing functionality for pull request links.