### PR TITLE
[DUCKLING] Add task processing timeout with settings integration and logging

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -84,6 +84,7 @@ duckling task cancel <taskId>
 - Commit suffix (default: ` [quack]`)
 - Base branch (default: `main`)
 - Maximum retries (default: 3)
+- Task timeout (default: 60 minutes)
 - Auto-merge (default: false)
 - Poll interval for PR comments (default: 30 seconds)
 

--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ graph TD
 | Commit Suffix | ` [quack]` | Suffix for commit messages |
 | Base Branch | `main` | Target branch for PRs |
 | Max Retries | `3` | Maximum retry attempts |
+| Task Timeout | `60 minutes` | Maximum time for task processing |
 | Poll Interval | `30s` | PR comment polling interval |
 | Auto-merge | `false` | Auto-merge approved PRs |
 | Comment prefix | `duckling` | Comments must start with this prefix to be processed |

--- a/public/js/settings.js
+++ b/public/js/settings.js
@@ -80,6 +80,7 @@ class Settings {
     document.getElementById('commit-suffix').value = settings.commitSuffix || ' [quack]';
     document.getElementById('comment-prefix').value = settings.commentPrefix || 'duckling';
     document.getElementById('max-retries').value = settings.maxRetries || 3;
+    document.getElementById('task-timeout-minutes').value = settings.taskTimeoutMinutes || 60;
 
 
     // Show configuration status
@@ -100,6 +101,7 @@ class Settings {
 
     // Convert numeric fields
     settings.maxRetries = parseInt(settings.maxRetries);
+    settings.taskTimeoutMinutes = parseInt(settings.taskTimeoutMinutes);
 
 
     try {

--- a/public/settings.html
+++ b/public/settings.html
@@ -189,6 +189,12 @@
               <p class="text-xs text-gray-500 mt-1">Maximum number of retry attempts when tasks fail due to transient
                 errors</p>
             </div>
+            <div>
+              <label for="task-timeout-minutes" class="block text-sm font-medium text-gray-700">Task Timeout (minutes)</label>
+              <input type="number" id="task-timeout-minutes" name="taskTimeoutMinutes" value="60" min="5" max="480" step="5"
+                class="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-gray-400 focus:border-gray-400">
+              <p class="text-xs text-gray-500 mt-1">Maximum time allowed for processing each task (including pending, in-progress, review processing, etc.)</p>
+            </div>
 
 
           </div>

--- a/src/core/engine.ts
+++ b/src/core/engine.ts
@@ -192,13 +192,62 @@ export class CoreEngine extends EventEmitter {
     }, 60000); // 1 minute
   }
 
+  private async withTaskTimeout<T>(
+    taskId: number,
+    operation: () => Promise<T>
+  ): Promise<T> {
+    const timeoutMinutes = this.settings.get('taskTimeoutMinutes');
+    const timeoutMs = timeoutMinutes * 60 * 1000;
+
+    return new Promise<T>((resolve, reject) => {
+      const timer = setTimeout(() => {
+        this.db.addTaskLog({
+          task_id: taskId,
+          level: 'warn',
+          message: `⏰ Task processing timed out after ${timeoutMinutes} minutes`,
+        });
+
+        // Update task status to failed due to timeout
+        this.db.updateTask(taskId, {
+          status: 'failed',
+          current_stage: 'timed_out',
+        });
+        this.emitTaskUpdate(taskId, 'failed');
+
+        reject(
+          new Error(`Task processing timed out after ${timeoutMinutes} minutes`)
+        );
+      }, timeoutMs);
+
+      operation()
+        .then((result) => {
+          clearTimeout(timer);
+          resolve(result);
+        })
+        .catch((error) => {
+          clearTimeout(timer);
+          reject(error);
+        });
+    });
+  }
+
   private async processPendingTasks(): Promise<void> {
     // Process pending and in_progress tasks (in case server was interrupted)
     const pendingTasks = this.db.getTasks({ status: 'pending' });
     const inProgressTasks = this.db.getTasks({ status: 'in-progress' });
 
     for (const task of [...pendingTasks, ...inProgressTasks]) {
-      await this.processTask(task.id);
+      try {
+        await this.withTaskTimeout(task.id, async () => {
+          await this.processTask(task.id);
+        });
+      } catch (error: any) {
+        this.db.addTaskLog({
+          task_id: task.id,
+          level: 'error',
+          message: `❌ Error processing task: ${error.message}`,
+        });
+      }
     }
   }
 
@@ -215,41 +264,43 @@ export class CoreEngine extends EventEmitter {
       }
 
       try {
-        const gitManager = this.getGitManager(task.repository_path);
-        await gitManager.switchToBranch(task.branch_name, task.id);
-        const result = await this.collectPRComments(task.id, task.pr_number);
+        await this.withTaskTimeout(task.id, async () => {
+          const gitManager = this.getGitManager(task.repository_path);
+          await gitManager.switchToBranch(task.branch_name!, task.id);
+          const result = await this.collectPRComments(task.id, task.pr_number!);
 
-        // Handle status updates first (completed/cancelled)
-        if (result.statusUpdate) {
-          if (result.statusUpdate === 'completed') {
-            this.db.updateTask(task.id, {
-              status: 'completed',
-              current_stage: 'completed',
-              completed_at: new Date().toISOString(),
-            });
-            this.emitTaskUpdate(task.id, 'completed');
-          } else if (result.statusUpdate === 'cancelled') {
-            this.db.updateTask(task.id, {
-              status: 'cancelled',
-              current_stage: 'cancelled',
-            });
-            this.emitTaskUpdate(task.id, 'cancelled');
+          // Handle status updates first (completed/cancelled)
+          if (result.statusUpdate) {
+            if (result.statusUpdate === 'completed') {
+              this.db.updateTask(task.id, {
+                status: 'completed',
+                current_stage: 'completed',
+                completed_at: new Date().toISOString(),
+              });
+              this.emitTaskUpdate(task.id, 'completed');
+            } else if (result.statusUpdate === 'cancelled') {
+              this.db.updateTask(task.id, {
+                status: 'cancelled',
+                current_stage: 'cancelled',
+              });
+              this.emitTaskUpdate(task.id, 'cancelled');
+            }
+            return; // Skip comment processing if task is completed/cancelled
           }
-          continue; // Skip comment processing if task is completed/cancelled
-        }
 
-        // If there are new comments, concatenate them and address all at once
-        if (result.comments.length > 0) {
-          const concatenatedComments = result.comments.join('\n\n---\n\n');
+          // If there are new comments, concatenate them and address all at once
+          if (result.comments.length > 0) {
+            const concatenatedComments = result.comments.join('\n\n---\n\n');
 
-          this.db.addTaskLog({
-            task_id: task.id,
-            level: 'info',
-            message: `💬 Processing ${result.comments.length} PR review comment(s)...`,
-          });
+            this.db.addTaskLog({
+              task_id: task.id,
+              level: 'info',
+              message: `💬 Processing ${result.comments.length} PR review comment(s)...`,
+            });
 
-          await this.handleAllPRComments(task.id, concatenatedComments);
-        }
+            await this.handleAllPRComments(task.id, concatenatedComments);
+          }
+        });
       } catch (error: any) {
         this.db.addTaskLog({
           task_id: task.id,

--- a/src/core/github-cli-provider.ts
+++ b/src/core/github-cli-provider.ts
@@ -449,15 +449,10 @@ export class GitHubCLIProvider {
 
       // Use GraphQL to get recent PRs and filter out tool-generated ones
       const graphqlQuery = `query { viewer { pullRequests(first: 5, states: [OPEN, CLOSED, MERGED], orderBy: {field: CREATED_AT, direction: DESC}) { nodes { number title body author { login } } } } }`;
-      
+
       const result = await execCommand(
         'gh',
-        [
-          'api',
-          'graphql',
-          '-f',
-          `query=${graphqlQuery}`
-        ],
+        ['api', 'graphql', '-f', `query=${graphqlQuery}`],
         { cwd: repositoryPath }
       );
 
@@ -467,10 +462,12 @@ export class GitHubCLIProvider {
       }
 
       const graphqlResponse = JSON.parse(result.stdout);
-      
+
       // Filter out PRs created by this tool (those with the prefix)
       const allPRs = graphqlResponse.data.viewer.pullRequests.nodes;
-      const recentPRs = allPRs.filter((pr: any) => !pr.title.startsWith(prTitlePrefix));
+      const recentPRs = allPRs.filter(
+        (pr: any) => !pr.title.startsWith(prTitlePrefix)
+      );
 
       // For each PR, try to get the diff as well
       const prsWithDiff = await Promise.all(
@@ -497,7 +494,9 @@ export class GitHubCLIProvider {
         })
       );
 
-      logger.info(`Found ${prsWithDiff.length} recent user PRs as examples (excluding tool-generated PRs)`);
+      logger.info(
+        `Found ${prsWithDiff.length} recent user PRs as examples (excluding tool-generated PRs)`
+      );
       return prsWithDiff;
     } catch (error) {
       logger.warn(`Failed to fetch recent PRs: ${error}`);

--- a/src/core/prompts.ts
+++ b/src/core/prompts.ts
@@ -44,9 +44,12 @@ ${pr.body}
       }
     });
 
-    if (examplesText === `Here are examples of recent PR descriptions from this repository (ONLY the description content, use these as style guides):
+    if (
+      examplesText ===
+      `Here are examples of recent PR descriptions from this repository (ONLY the description content, use these as style guides):
 
-`) {
+`
+    ) {
       examplesText = ''; // No examples found
     }
   }

--- a/src/core/settings-manager.ts
+++ b/src/core/settings-manager.ts
@@ -11,6 +11,7 @@ export interface SettingsDefaults {
   maxRetries: number;
   openaiApiKey: string;
   customPrompt: string;
+  taskTimeoutMinutes: number;
 }
 
 export class SettingsManager {
@@ -23,6 +24,7 @@ export class SettingsManager {
     maxRetries: 3,
     openaiApiKey: '',
     customPrompt: DEFAULT_CODING_PROMPT,
+    taskTimeoutMinutes: 60,
   };
 
   constructor(private db: DatabaseManager) {}


### PR DESCRIPTION
### Summary

This pull request introduces a time limit for task processing to ensure tasks do not exceed their allocated duration. The default time limit is set to 60 minutes and can be configured via the settings page.

### Changes

- Added a time limit for task processing set by default to 60 minutes.
- Incorporated task timeout setting into the `processReviews` and `processPendingTasks` functions.
- Updated the AGENT.md and README.md to reflect the new task timeout setting.
- Modified `settings.js` to include `taskTimeoutMinutes` for configuration.
- Enhanced `settings.html` to allow user input for task timeout value.

### Logging

- Implemented logging to record when tasks exceed the specified time limit and are terminated.

### Settings

- Task timeout can be adjusted on the settings page, which updates both the front-end display and back-end process configurations.