### PR TITLE
[DUCKLING] Add unit tests for all TypeScript files with Jest configuration

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,19 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  roots: ['<rootDir>/src'],
+  testMatch: ['**/__tests__/**/*.test.ts'],
+  transform: {
+    '^.+\\.ts$': 'ts-jest',
+  },
+  collectCoverageFrom: [
+    'src/**/*.ts',
+    '!src/**/*.d.ts',
+    '!src/index.ts',
+    '!src/cli.ts',
+    '!src/cli/index.ts',
+  ],
+  coverageDirectory: 'coverage',
+  testTimeout: 10000,
+  setupFilesAfterEnv: ['<rootDir>/src/__tests__/setup.ts'],
+};

--- a/src/__tests__/setup.ts
+++ b/src/__tests__/setup.ts
@@ -1,0 +1,65 @@
+// Jest setup file
+
+// Mock fs for tests that don't need actual file system
+jest.mock('fs', () => ({
+  ...jest.requireActual('fs'),
+  existsSync: jest.fn(),
+  readFileSync: jest.fn(),
+  writeFileSync: jest.fn(),
+  mkdirSync: jest.fn(),
+  appendFileSync: jest.fn(),
+}));
+
+// Mock better-sqlite3 for database tests
+jest.mock('better-sqlite3', () => {
+  return jest.fn().mockImplementation(() => ({
+    pragma: jest.fn(),
+    exec: jest.fn(),
+    prepare: jest.fn().mockReturnValue({
+      run: jest.fn(),
+      get: jest.fn(),
+      all: jest.fn(),
+    }),
+    close: jest.fn(),
+  }));
+});
+
+// Mock execa for exec tests
+jest.mock('execa', () => ({
+  execa: jest.fn(),
+}));
+
+// Mock simple-git
+jest.mock('simple-git', () => ({
+  simpleGit: jest.fn().mockReturnValue({
+    init: jest.fn(),
+    add: jest.fn(),
+    commit: jest.fn(),
+    push: jest.fn(),
+    checkout: jest.fn(),
+    checkoutBranch: jest.fn(),
+    status: jest.fn(),
+    branch: jest.fn(),
+    raw: jest.fn(),
+  }),
+}));
+
+// Mock openai
+jest.mock('openai', () => ({
+  OpenAI: jest.fn().mockImplementation(() => ({
+    chat: {
+      completions: {
+        create: jest.fn(),
+      },
+    },
+  })),
+}));
+
+// Set up global test environment
+global.console = {
+  ...console,
+  log: jest.fn(),
+  error: jest.fn(),
+  warn: jest.fn(),
+  info: jest.fn(),
+};

--- a/src/core/__tests__/coding-manager.test.ts
+++ b/src/core/__tests__/coding-manager.test.ts
@@ -1,0 +1,183 @@
+import { CodingManager } from '../coding-manager';
+import { exec } from '../../utils/exec';
+import { logger } from '../../utils/logger';
+
+jest.mock('../../utils/exec');
+jest.mock('../../utils/logger');
+
+const mockExec = exec as jest.MockedFunction<typeof exec>;
+const mockLogger = logger as jest.Mocked<typeof logger>;
+
+describe('CodingManager', () => {
+  let codingManager: CodingManager;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    codingManager = new CodingManager();
+  });
+
+  describe('executeTask', () => {
+    it('should execute task with amp tool', async () => {
+      mockExec.mockResolvedValue({
+        stdout: 'Task completed successfully',
+        stderr: '',
+        exitCode: 0,
+      });
+
+      await codingManager.executeTask('Fix authentication bug', 'amp', 1);
+
+      expect(mockExec).toHaveBeenCalledWith('amp "Fix authentication bug"', { cwd: process.cwd() });
+      expect(mockLogger.info).toHaveBeenCalledWith('Starting coding task with amp', '1');
+      expect(mockLogger.info).toHaveBeenCalledWith('Coding task completed successfully', '1');
+    });
+
+    it('should execute task with openai tool', async () => {
+      mockExec.mockResolvedValue({
+        stdout: 'Task completed with OpenAI',
+        stderr: '',
+        exitCode: 0,
+      });
+
+      await codingManager.executeTask('Add new feature', 'openai', 2);
+
+      expect(mockExec).toHaveBeenCalledWith('openai "Add new feature"', { cwd: process.cwd() });
+      expect(mockLogger.info).toHaveBeenCalledWith('Starting coding task with openai', '2');
+      expect(mockLogger.info).toHaveBeenCalledWith('Coding task completed successfully', '2');
+    });
+
+    it('should handle task execution failure', async () => {
+      const error = new Error('Command failed');
+      mockExec.mockRejectedValue(error);
+
+      await expect(codingManager.executeTask('Failing task', 'amp', 1)).rejects.toThrow('Command failed');
+
+      expect(mockLogger.error).toHaveBeenCalledWith('Coding task failed: Command failed', '1');
+    });
+
+    it('should handle invalid tool', async () => {
+      await expect(codingManager.executeTask('Test task', 'invalid-tool' as any, 1)).rejects.toThrow('Unsupported coding tool: invalid-tool');
+    });
+
+    it('should execute task with custom working directory', async () => {
+      mockExec.mockResolvedValue({
+        stdout: 'Task completed',
+        stderr: '',
+        exitCode: 0,
+      });
+
+      await codingManager.executeTask('Test task', 'amp', 1, '/custom/path');
+
+      expect(mockExec).toHaveBeenCalledWith('amp "Test task"', { cwd: '/custom/path' });
+    });
+
+    it('should handle empty task description', async () => {
+      mockExec.mockResolvedValue({
+        stdout: 'Empty task completed',
+        stderr: '',
+        exitCode: 0,
+      });
+
+      await codingManager.executeTask('', 'amp', 1);
+
+      expect(mockExec).toHaveBeenCalledWith('amp ""', { cwd: process.cwd() });
+    });
+
+    it('should handle task with special characters', async () => {
+      mockExec.mockResolvedValue({
+        stdout: 'Special task completed',
+        stderr: '',
+        exitCode: 0,
+      });
+
+      await codingManager.executeTask('Fix "bug" with \\'quotes\\'', 'amp', 1);
+
+      expect(mockExec).toHaveBeenCalledWith('amp "Fix \\"bug\\" with \'quotes\'"', { cwd: process.cwd() });
+    });
+
+    it('should log stderr output as warning', async () => {
+      mockExec.mockResolvedValue({
+        stdout: 'Task completed',
+        stderr: 'Some warnings occurred',
+        exitCode: 0,
+      });
+
+      await codingManager.executeTask('Test task', 'amp', 1);
+
+      expect(mockLogger.warn).toHaveBeenCalledWith('Coding task stderr: Some warnings occurred', '1');
+    });
+
+    it('should handle non-zero exit code', async () => {
+      mockExec.mockResolvedValue({
+        stdout: 'Task output',
+        stderr: 'Error occurred',
+        exitCode: 1,
+      });
+
+      await expect(codingManager.executeTask('Failing task', 'amp', 1)).rejects.toThrow('Coding task failed with exit code 1');
+    });
+  });
+
+  describe('isToolAvailable', () => {
+    it('should check if amp tool is available', async () => {
+      mockExec.mockResolvedValue({
+        stdout: 'amp version 1.0.0',
+        stderr: '',
+        exitCode: 0,
+      });
+
+      const result = await codingManager.isToolAvailable('amp');
+
+      expect(result).toBe(true);
+      expect(mockExec).toHaveBeenCalledWith('amp --version');
+    });
+
+    it('should check if openai tool is available', async () => {
+      mockExec.mockResolvedValue({
+        stdout: 'openai version 1.0.0',
+        stderr: '',
+        exitCode: 0,
+      });
+
+      const result = await codingManager.isToolAvailable('openai');
+
+      expect(result).toBe(true);
+      expect(mockExec).toHaveBeenCalledWith('openai --version');
+    });
+
+    it('should return false if tool is not available', async () => {
+      mockExec.mockRejectedValue(new Error('Command not found'));
+
+      const result = await codingManager.isToolAvailable('amp');
+
+      expect(result).toBe(false);
+    });
+
+    it('should handle invalid tool for availability check', async () => {
+      const result = await codingManager.isToolAvailable('invalid-tool' as any);
+
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('getSupportedTools', () => {
+    it('should return list of supported tools', () => {
+      const tools = codingManager.getSupportedTools();
+
+      expect(tools).toEqual(['amp', 'openai']);
+    });
+  });
+
+  describe('validateTool', () => {
+    it('should validate amp tool', () => {
+      expect(() => codingManager.validateTool('amp')).not.toThrow();
+    });
+
+    it('should validate openai tool', () => {
+      expect(() => codingManager.validateTool('openai')).not.toThrow();
+    });
+
+    it('should throw error for invalid tool', () => {
+      expect(() => codingManager.validateTool('invalid-tool' as any)).toThrow('Unsupported coding tool: invalid-tool');
+    });
+  });
+});

--- a/src/core/__tests__/database.test.ts
+++ b/src/core/__tests__/database.test.ts
@@ -1,0 +1,404 @@
+import Database from 'better-sqlite3';
+import fs from 'fs';
+import { DatabaseManager } from '../database';
+import { DUCKLING_DIR, DATABASE_PATH } from '../../utils/constants';
+
+jest.mock('better-sqlite3');
+jest.mock('fs');
+jest.mock('../migrations');
+
+const mockDatabase = {
+  pragma: jest.fn(),
+  exec: jest.fn(),
+  prepare: jest.fn(),
+  close: jest.fn(),
+};
+
+const mockFs = fs as jest.Mocked<typeof fs>;
+const mockDatabaseConstructor = Database as jest.MockedClass<typeof Database>;
+
+describe('DatabaseManager', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockFs.existsSync.mockReturnValue(true);
+    mockDatabaseConstructor.mockReturnValue(mockDatabase as any);
+    
+    mockDatabase.prepare.mockReturnValue({
+      run: jest.fn(),
+      get: jest.fn(),
+      all: jest.fn(),
+    } as any);
+  });
+
+  describe('Constructor', () => {
+    it('should create DUCKLING_DIR if it does not exist', () => {
+      mockFs.existsSync.mockReturnValue(false);
+      
+      new DatabaseManager();
+      
+      expect(mockFs.mkdirSync).toHaveBeenCalledWith(DUCKLING_DIR, { recursive: true });
+    });
+
+    it('should initialize database with correct path', () => {
+      new DatabaseManager();
+      
+      expect(mockDatabaseConstructor).toHaveBeenCalledWith(DATABASE_PATH);
+    });
+
+    it('should enable WAL mode', () => {
+      new DatabaseManager();
+      
+      expect(mockDatabase.pragma).toHaveBeenCalledWith('journal_mode = WAL');
+    });
+
+    it('should initialize tables', () => {
+      new DatabaseManager();
+      
+      expect(mockDatabase.exec).toHaveBeenCalledWith(
+        expect.stringContaining('CREATE TABLE IF NOT EXISTS repositories')
+      );
+      expect(mockDatabase.exec).toHaveBeenCalledWith(
+        expect.stringContaining('CREATE TABLE IF NOT EXISTS tasks')
+      );
+      expect(mockDatabase.exec).toHaveBeenCalledWith(
+        expect.stringContaining('CREATE TABLE IF NOT EXISTS task_logs')
+      );
+      expect(mockDatabase.exec).toHaveBeenCalledWith(
+        expect.stringContaining('CREATE TABLE IF NOT EXISTS settings')
+      );
+      expect(mockDatabase.exec).toHaveBeenCalledWith(
+        expect.stringContaining('CREATE TABLE IF NOT EXISTS precommit_checks')
+      );
+    });
+  });
+
+  describe('Task Management', () => {
+    let dbManager: DatabaseManager;
+
+    beforeEach(() => {
+      dbManager = new DatabaseManager();
+    });
+
+    describe('createTask', () => {
+      it('should create a new task', () => {
+        const mockRun = jest.fn().mockReturnValue({ lastInsertRowid: 1 });
+        mockDatabase.prepare.mockReturnValue({ run: mockRun } as any);
+
+        const result = dbManager.createTask({
+          title: 'Test Task',
+          description: 'Test Description',
+          coding_tool: 'openai',
+          repository_path: '/test/path',
+          status: 'pending',
+          created_at: new Date().toISOString(),
+          updated_at: new Date().toISOString(),
+        } as any);
+
+        expect(result).toBe(1);
+        expect(mockDatabase.prepare).toHaveBeenCalledWith(
+          expect.stringContaining('INSERT INTO tasks')
+        );
+        expect(mockRun).toHaveBeenCalledWith(
+          'Test Task',
+          'Test Description',
+          null,
+          'pending',
+          'openai',
+          '/test/path',
+          null,
+          null,
+          null,
+          null,
+          null
+        );
+      });
+    });
+
+    describe('getTask', () => {
+      it('should get a task by id', () => {
+        const mockTask = { id: 1, title: 'Test Task' };
+        const mockGet = jest.fn().mockReturnValue(mockTask);
+        mockDatabase.prepare.mockReturnValue({ get: mockGet } as any);
+
+        const result = dbManager.getTask(1);
+
+        expect(result).toBe(mockTask);
+        expect(mockDatabase.prepare).toHaveBeenCalledWith(
+          expect.stringContaining('SELECT * FROM tasks WHERE id = ?')
+        );
+        expect(mockGet).toHaveBeenCalledWith(1);
+      });
+
+      it('should return null for non-existent task', () => {
+        const mockGet = jest.fn().mockReturnValue(null);
+        mockDatabase.prepare.mockReturnValue({ get: mockGet } as any);
+
+        const result = dbManager.getTask(999);
+
+        expect(result).toBeNull();
+        expect(mockGet).toHaveBeenCalledWith(999);
+      });
+    });
+
+    describe('getTasks', () => {
+      it('should get all tasks', () => {
+        const mockTasks = [
+          { id: 1, title: 'Task 1' },
+          { id: 2, title: 'Task 2' }
+        ];
+        const mockAll = jest.fn().mockReturnValue(mockTasks);
+        mockDatabase.prepare.mockReturnValue({ all: mockAll } as any);
+
+        const result = dbManager.getTasks();
+
+        expect(result).toBe(mockTasks);
+        expect(mockDatabase.prepare).toHaveBeenCalledWith(
+          expect.stringContaining('SELECT * FROM tasks ORDER BY created_at DESC')
+        );
+        expect(mockAll).toHaveBeenCalled();
+      });
+    });
+
+    describe('updateTask', () => {
+      it('should update task status', () => {
+        const mockRun = jest.fn();
+        mockDatabase.prepare.mockReturnValue({ run: mockRun } as any);
+
+        dbManager.updateTask(1, { status: 'completed' });
+
+        expect(mockDatabase.prepare).toHaveBeenLastCalledWith(
+          expect.stringContaining('UPDATE tasks')
+        );
+        expect(mockRun).toHaveBeenCalledWith(
+          'completed',
+          1
+        );
+      });
+
+      it('should update multiple fields', () => {
+        const mockRun = jest.fn();
+        mockDatabase.prepare.mockReturnValue({ run: mockRun } as any);
+
+        dbManager.updateTask(1, {
+          status: 'completed',
+          summary: 'Test Summary',
+          branch_name: 'test-branch'
+        });
+
+        expect(mockDatabase.prepare).toHaveBeenLastCalledWith(
+          expect.stringContaining('UPDATE tasks')
+        );
+        expect(mockRun).toHaveBeenCalledWith(
+          'completed',
+          'Test Summary',
+          'test-branch',
+          1
+        );
+      });
+    });
+
+    describe('deleteTask', () => {
+      it('should delete a task', () => {
+        const mockRun = jest.fn();
+        mockDatabase.prepare.mockReturnValue({ run: mockRun } as any);
+
+        dbManager.deleteTask(1);
+
+        expect(mockDatabase.prepare).toHaveBeenCalledWith(
+          expect.stringContaining('DELETE FROM tasks WHERE id = ?')
+        );
+        expect(mockRun).toHaveBeenCalledWith(1);
+      });
+    });
+  });
+
+  describe('Task Logs', () => {
+    let dbManager: DatabaseManager;
+
+    beforeEach(() => {
+      dbManager = new DatabaseManager();
+    });
+
+    describe('addTaskLog', () => {
+      it('should add a task log', () => {
+        const mockRun = jest.fn();
+        mockDatabase.prepare.mockReturnValue({ run: mockRun } as any);
+
+        dbManager.addTaskLog({
+          task_id: 1,
+          level: 'info',
+          message: 'Test message'
+        });
+
+        expect(mockDatabase.prepare).toHaveBeenCalledWith(
+          expect.stringContaining('INSERT INTO task_logs')
+        );
+        expect(mockRun).toHaveBeenCalledWith(1, 'info', 'Test message');
+      });
+    });
+
+    describe('getTaskLogs', () => {
+      it('should get task logs', () => {
+        const mockLogs = [
+          { id: 1, message: 'Log 1' },
+          { id: 2, message: 'Log 2' }
+        ];
+        const mockAll = jest.fn().mockReturnValue(mockLogs);
+        mockDatabase.prepare.mockReturnValue({ all: mockAll } as any);
+
+        const result = dbManager.getTaskLogs(1);
+
+        expect(result).toBe(mockLogs);
+        expect(mockDatabase.prepare).toHaveBeenCalledWith(
+          expect.stringContaining('SELECT * FROM task_logs WHERE task_id = ?')
+        );
+        expect(mockAll).toHaveBeenCalledWith(1);
+      });
+    });
+  });
+
+  describe('Settings Management', () => {
+    let dbManager: DatabaseManager;
+
+    beforeEach(() => {
+      dbManager = new DatabaseManager();
+    });
+
+    describe('setSetting', () => {
+      it('should set a setting', () => {
+        const mockRun = jest.fn();
+        mockDatabase.prepare.mockReturnValue({ run: mockRun } as any);
+
+        dbManager.setSetting('test_key', 'test_value');
+
+        expect(mockDatabase.prepare).toHaveBeenCalledWith(
+          expect.stringContaining('INSERT OR REPLACE INTO settings')
+        );
+        expect(mockRun).toHaveBeenCalledWith('test_key', 'test_value');
+      });
+    });
+
+    describe('getSetting', () => {
+      it('should get a setting', () => {
+        const mockSetting = { key: 'test_key', value: 'test_value' };
+        const mockGet = jest.fn().mockReturnValue(mockSetting);
+        mockDatabase.prepare.mockReturnValue({ get: mockGet } as any);
+
+        const result = dbManager.getSetting('test_key');
+
+        expect(result).toBe(mockSetting);
+        expect(mockDatabase.prepare).toHaveBeenCalledWith(
+          expect.stringContaining('SELECT * FROM settings WHERE key = ?')
+        );
+        expect(mockGet).toHaveBeenCalledWith('test_key');
+      });
+    });
+
+    describe('getAllSettings', () => {
+      it('should get all settings', () => {
+        const mockSettings = [
+          { key: 'key1', value: 'value1' },
+          { key: 'key2', value: 'value2' }
+        ];
+        const mockAll = jest.fn().mockReturnValue(mockSettings);
+        mockDatabase.prepare.mockReturnValue({ all: mockAll } as any);
+
+        const result = dbManager.getSettings();
+
+        expect(result).toBe(mockSettings);
+        expect(mockDatabase.prepare).toHaveBeenCalledWith(
+          expect.stringContaining('SELECT * FROM settings')
+        );
+        expect(mockAll).toHaveBeenCalled();
+      });
+    });
+  });
+
+  describe('Repository Management', () => {
+    let dbManager: DatabaseManager;
+
+    beforeEach(() => {
+      dbManager = new DatabaseManager();
+    });
+
+    describe('getRepository', () => {
+      it('should get existing repository', () => {
+        const mockRepo = { id: 1, path: '/test/path', name: 'test', owner: 'owner' };
+        const mockGet = jest.fn().mockReturnValue(mockRepo);
+        mockDatabase.prepare.mockReturnValue({ get: mockGet } as any);
+
+        const result = dbManager.getRepository('/test/path');
+
+        expect(result).toBe(mockRepo);
+        expect(mockDatabase.prepare).toHaveBeenCalledWith(
+          expect.stringContaining('SELECT * FROM repositories WHERE path = ?')
+        );
+        expect(mockGet).toHaveBeenCalledWith('/test/path');
+      });
+
+      it('should return null for non-existent repository', () => {
+        const mockGet = jest.fn().mockReturnValue(null);
+        mockDatabase.prepare.mockReturnValue({ get: mockGet } as any);
+
+        const result = dbManager.getRepository('/non/existent/path');
+
+        expect(result).toBeNull();
+        expect(mockGet).toHaveBeenCalledWith('/non/existent/path');
+      });
+    });
+
+    describe('addRepository', () => {
+      it('should add a new repository', () => {
+        const mockRun = jest.fn().mockReturnValue({ lastInsertRowid: 1 });
+        mockDatabase.prepare.mockReturnValue({ run: mockRun } as any);
+
+        const result = dbManager.addRepository({
+          path: '/test/path',
+          name: 'test',
+          owner: 'owner'
+        });
+
+        expect(result).toBe(1);
+        expect(mockDatabase.prepare).toHaveBeenCalledWith(
+          expect.stringContaining('INSERT INTO repositories')
+        );
+        expect(mockRun).toHaveBeenCalledWith('/test/path', 'test', 'owner');
+      });
+    });
+
+    describe('getRepositories', () => {
+      it('should get all repositories', () => {
+        const mockRepos = [
+          { id: 1, path: '/test/path1', name: 'test1', owner: 'owner1' },
+          { id: 2, path: '/test/path2', name: 'test2', owner: 'owner2' }
+        ];
+        const mockAll = jest.fn().mockReturnValue(mockRepos);
+        mockDatabase.prepare.mockReturnValue({ all: mockAll } as any);
+
+        const result = dbManager.getRepositories();
+
+        expect(result).toBe(mockRepos);
+        expect(mockDatabase.prepare).toHaveBeenLastCalledWith(
+          expect.stringContaining('SELECT * FROM repositories ORDER BY created_at ASC')
+        );
+        expect(mockAll).toHaveBeenCalled();
+      });
+    });
+  });
+
+  describe('Database Connection', () => {
+    let dbManager: DatabaseManager;
+
+    beforeEach(() => {
+      dbManager = new DatabaseManager();
+    });
+
+    describe('close', () => {
+      it('should close database connection', () => {
+        dbManager.close();
+        
+        expect(mockDatabase.close).toHaveBeenCalled();
+      });
+    });
+  });
+});

--- a/src/core/__tests__/openai-manager.test.ts
+++ b/src/core/__tests__/openai-manager.test.ts
@@ -1,0 +1,237 @@
+import { OpenAIManager } from '../openai-manager';
+import { OpenAI } from 'openai';
+
+jest.mock('openai');
+
+const mockOpenAI = OpenAI as jest.MockedClass<typeof OpenAI>;
+
+describe('OpenAIManager', () => {
+  let openaiManager: OpenAIManager;
+  let mockChatCompletions: jest.Mocked<OpenAI['chat']['completions']>;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    
+    mockChatCompletions = {
+      create: jest.fn(),
+    } as any;
+
+    mockOpenAI.mockImplementation(() => ({
+      chat: {
+        completions: mockChatCompletions,
+      },
+    } as any));
+
+    openaiManager = new OpenAIManager('test-api-key');
+  });
+
+  describe('Constructor', () => {
+    it('should initialize with API key', () => {
+      expect(mockOpenAI).toHaveBeenCalledWith({
+        apiKey: 'test-api-key',
+      });
+    });
+
+    it('should throw error with empty API key', () => {
+      expect(() => new OpenAIManager('')).toThrow('OpenAI API key is required');
+    });
+
+    it('should throw error with undefined API key', () => {
+      expect(() => new OpenAIManager(undefined as any)).toThrow('OpenAI API key is required');
+    });
+  });
+
+  describe('generateText', () => {
+    it('should generate text from prompt', async () => {
+      const mockResponse = {
+        choices: [
+          {
+            message: {
+              content: 'Generated response',
+            },
+          },
+        ],
+      };
+
+      mockChatCompletions.create.mockResolvedValue(mockResponse as any);
+
+      const result = await openaiManager.generateText('Test prompt');
+
+      expect(result).toBe('Generated response');
+      expect(mockChatCompletions.create).toHaveBeenCalledWith({
+        model: 'gpt-3.5-turbo',
+        messages: [
+          {
+            role: 'user',
+            content: 'Test prompt',
+          },
+        ],
+        max_tokens: 150,
+        temperature: 0.7,
+      });
+    });
+
+    it('should handle empty response', async () => {
+      const mockResponse = {
+        choices: [
+          {
+            message: {
+              content: null,
+            },
+          },
+        ],
+      };
+
+      mockChatCompletions.create.mockResolvedValue(mockResponse as any);
+
+      const result = await openaiManager.generateText('Test prompt');
+
+      expect(result).toBe('');
+    });
+
+    it('should handle no choices in response', async () => {
+      const mockResponse = {
+        choices: [],
+      };
+
+      mockChatCompletions.create.mockResolvedValue(mockResponse as any);
+
+      const result = await openaiManager.generateText('Test prompt');
+
+      expect(result).toBe('');
+    });
+
+    it('should handle API errors', async () => {
+      const error = new Error('API Error');
+      mockChatCompletions.create.mockRejectedValue(error);
+
+      await expect(openaiManager.generateText('Test prompt')).rejects.toThrow('API Error');
+    });
+
+    it('should use custom model when specified', async () => {
+      const mockResponse = {
+        choices: [
+          {
+            message: {
+              content: 'Generated response',
+            },
+          },
+        ],
+      };
+
+      mockChatCompletions.create.mockResolvedValue(mockResponse as any);
+
+      await openaiManager.generateText('Test prompt', 'gpt-4');
+
+      expect(mockChatCompletions.create).toHaveBeenCalledWith({
+        model: 'gpt-4',
+        messages: [
+          {
+            role: 'user',
+            content: 'Test prompt',
+          },
+        ],
+        max_tokens: 150,
+        temperature: 0.7,
+      });
+    });
+  });
+
+  describe('generateCommitMessage', () => {
+    it('should generate commit message from changes', async () => {
+      const mockResponse = {
+        choices: [
+          {
+            message: {
+              content: 'feat: add user authentication',
+            },
+          },
+        ],
+      };
+
+      mockChatCompletions.create.mockResolvedValue(mockResponse as any);
+
+      const result = await openaiManager.generateCommitMessage('Added auth module');
+
+      expect(result).toBe('feat: add user authentication');
+      expect(mockChatCompletions.create).toHaveBeenCalledWith({
+        model: 'gpt-3.5-turbo',
+        messages: [
+          {
+            role: 'user',
+            content: expect.stringContaining('Added auth module'),
+          },
+        ],
+        max_tokens: 150,
+        temperature: 0.7,
+      });
+    });
+
+    it('should handle empty changes', async () => {
+      const mockResponse = {
+        choices: [
+          {
+            message: {
+              content: 'chore: update files',
+            },
+          },
+        ],
+      };
+
+      mockChatCompletions.create.mockResolvedValue(mockResponse as any);
+
+      const result = await openaiManager.generateCommitMessage('');
+
+      expect(result).toBe('chore: update files');
+    });
+  });
+
+  describe('generateTaskSummary', () => {
+    it('should generate task summary', async () => {
+      const mockResponse = {
+        choices: [
+          {
+            message: {
+              content: 'Successfully implemented user authentication with JWT tokens',
+            },
+          },
+        ],
+      };
+
+      mockChatCompletions.create.mockResolvedValue(mockResponse as any);
+
+      const result = await openaiManager.generateTaskSummary('Add user authentication');
+
+      expect(result).toBe('Successfully implemented user authentication with JWT tokens');
+      expect(mockChatCompletions.create).toHaveBeenCalledWith({
+        model: 'gpt-3.5-turbo',
+        messages: [
+          {
+            role: 'user',
+            content: expect.stringContaining('Add user authentication'),
+          },
+        ],
+        max_tokens: 150,
+        temperature: 0.7,
+      });
+    });
+
+    it('should handle empty task', async () => {
+      const mockResponse = {
+        choices: [
+          {
+            message: {
+              content: 'Task completed successfully',
+            },
+          },
+        ],
+      };
+
+      mockChatCompletions.create.mockResolvedValue(mockResponse as any);
+
+      const result = await openaiManager.generateTaskSummary('');
+
+      expect(result).toBe('Task completed successfully');
+    });
+  });
+});

--- a/src/core/__tests__/prompts.test.ts
+++ b/src/core/__tests__/prompts.test.ts
@@ -1,0 +1,74 @@
+import { 
+  DEFAULT_CODING_PROMPT, 
+  generateCommitMessage, 
+  generateTaskSummary 
+} from '../prompts';
+
+describe('Prompts', () => {
+  describe('DEFAULT_CODING_PROMPT', () => {
+    it('should contain essential instructions', () => {
+      expect(DEFAULT_CODING_PROMPT).toContain('You are a helpful coding assistant');
+      expect(DEFAULT_CODING_PROMPT).toContain('analyze the repository');
+      expect(DEFAULT_CODING_PROMPT).toContain('implement the requested changes');
+      expect(DEFAULT_CODING_PROMPT).toContain('follow best practices');
+    });
+
+    it('should be a non-empty string', () => {
+      expect(DEFAULT_CODING_PROMPT).toBeTruthy();
+      expect(typeof DEFAULT_CODING_PROMPT).toBe('string');
+      expect(DEFAULT_CODING_PROMPT.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('generateCommitMessage', () => {
+    it('should generate commit message prompt', () => {
+      const changes = 'Added new authentication feature';
+      const prompt = generateCommitMessage(changes);
+
+      expect(prompt).toContain('Generate a concise commit message');
+      expect(prompt).toContain(changes);
+      expect(prompt).toContain('conventional commit format');
+    });
+
+    it('should handle empty changes', () => {
+      const prompt = generateCommitMessage('');
+
+      expect(prompt).toContain('Generate a concise commit message');
+      expect(prompt).toContain('conventional commit format');
+    });
+
+    it('should handle multiline changes', () => {
+      const changes = 'Added authentication\\nFixed bug\\nUpdated tests';
+      const prompt = generateCommitMessage(changes);
+
+      expect(prompt).toContain(changes);
+      expect(prompt).toContain('conventional commit format');
+    });
+  });
+
+  describe('generateTaskSummary', () => {
+    it('should generate task summary prompt', () => {
+      const task = 'Fix authentication bug in login module';
+      const prompt = generateTaskSummary(task);
+
+      expect(prompt).toContain('Generate a brief summary');
+      expect(prompt).toContain(task);
+      expect(prompt).toContain('what was accomplished');
+    });
+
+    it('should handle empty task', () => {
+      const prompt = generateTaskSummary('');
+
+      expect(prompt).toContain('Generate a brief summary');
+      expect(prompt).toContain('what was accomplished');
+    });
+
+    it('should handle complex task descriptions', () => {
+      const task = 'Implement OAuth2 authentication with JWT tokens and refresh token rotation';
+      const prompt = generateTaskSummary(task);
+
+      expect(prompt).toContain(task);
+      expect(prompt).toContain('what was accomplished');
+    });
+  });
+});

--- a/src/core/__tests__/settings-manager.test.ts
+++ b/src/core/__tests__/settings-manager.test.ts
@@ -1,0 +1,224 @@
+import { SettingsManager } from '../settings-manager';
+import { DatabaseManager } from '../database';
+import { DEFAULT_CODING_PROMPT } from '../prompts';
+
+jest.mock('../database');
+
+const mockDatabaseManager = {
+  getSetting: jest.fn(),
+  setSetting: jest.fn(),
+} as unknown as jest.Mocked<DatabaseManager>;
+
+describe('SettingsManager', () => {
+  let settingsManager: SettingsManager;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    settingsManager = new SettingsManager(mockDatabaseManager);
+  });
+
+  describe('get', () => {
+    it('should return setting value from database', () => {
+      mockDatabaseManager.getSetting.mockReturnValue({
+        key: 'branchPrefix',
+        value: 'feature-',
+        updated_at: '2023-01-01T00:00:00Z',
+      });
+
+      const result = settingsManager.get('branchPrefix');
+
+      expect(result).toBe('feature-');
+      expect(mockDatabaseManager.getSetting).toHaveBeenCalledWith('branchPrefix');
+    });
+
+    it('should return default value when setting not found', () => {
+      mockDatabaseManager.getSetting.mockReturnValue(null);
+
+      const result = settingsManager.get('branchPrefix');
+
+      expect(result).toBe('duckling-');
+      expect(mockDatabaseManager.getSetting).toHaveBeenCalledWith('branchPrefix');
+    });
+
+    it('should return default value when setting value is undefined', () => {
+      mockDatabaseManager.getSetting.mockReturnValue({
+        key: 'branchPrefix',
+        value: undefined as any,
+        updated_at: '2023-01-01T00:00:00Z',
+      });
+
+      const result = settingsManager.get('branchPrefix');
+
+      expect(result).toBe('duckling-');
+    });
+
+    it('should convert string to number for numeric settings', () => {
+      mockDatabaseManager.getSetting.mockReturnValue({
+        key: 'maxRetries',
+        value: '5',
+        updated_at: '2023-01-01T00:00:00Z',
+      });
+
+      const result = settingsManager.get('maxRetries');
+
+      expect(result).toBe(5);
+      expect(typeof result).toBe('number');
+    });
+
+    it('should handle all setting types', () => {
+      // Test string setting
+      mockDatabaseManager.getSetting.mockReturnValue({
+        key: 'defaultCodingTool',
+        value: 'openai',
+        updated_at: '2023-01-01T00:00:00Z',
+      });
+
+      const codingTool = settingsManager.get('defaultCodingTool');
+      expect(codingTool).toBe('openai');
+
+      // Test number setting
+      mockDatabaseManager.getSetting.mockReturnValue({
+        key: 'maxRetries',
+        value: '10',
+        updated_at: '2023-01-01T00:00:00Z',
+      });
+
+      const maxRetries = settingsManager.get('maxRetries');
+      expect(maxRetries).toBe(10);
+    });
+  });
+
+  describe('set', () => {
+    it('should set string setting', () => {
+      settingsManager.set('branchPrefix', 'feature-');
+
+      expect(mockDatabaseManager.setSetting).toHaveBeenCalledWith('branchPrefix', 'feature-');
+    });
+
+    it('should set number setting', () => {
+      settingsManager.set('maxRetries', 5);
+
+      expect(mockDatabaseManager.setSetting).toHaveBeenCalledWith('maxRetries', '5');
+    });
+
+    it('should set coding tool setting', () => {
+      settingsManager.set('defaultCodingTool', 'openai');
+
+      expect(mockDatabaseManager.setSetting).toHaveBeenCalledWith('defaultCodingTool', 'openai');
+    });
+
+    it('should handle empty string', () => {
+      settingsManager.set('openaiApiKey', '');
+
+      expect(mockDatabaseManager.setSetting).toHaveBeenCalledWith('openaiApiKey', '');
+    });
+  });
+
+  describe('getAll', () => {
+    it('should return all settings with defaults', () => {
+      mockDatabaseManager.getSetting.mockReturnValue(null);
+
+      const result = settingsManager.getAll();
+
+      expect(result).toEqual({
+        defaultCodingTool: 'amp',
+        branchPrefix: 'duckling-',
+        prTitlePrefix: '[DUCKLING]',
+        commitSuffix: ' [quack]',
+        commentPrefix: 'duckling',
+        maxRetries: 3,
+        openaiApiKey: '',
+        customPrompt: DEFAULT_CODING_PROMPT,
+      });
+    });
+
+    it('should return all settings with custom values', () => {
+      mockDatabaseManager.getSetting.mockImplementation((key) => {
+        const settings: Record<string, any> = {
+          defaultCodingTool: { value: 'openai' },
+          branchPrefix: { value: 'feature-' },
+          prTitlePrefix: { value: '[FEATURE]' },
+          commitSuffix: { value: ' [done]' },
+          commentPrefix: { value: 'bot' },
+          maxRetries: { value: '5' },
+          openaiApiKey: { value: 'sk-test' },
+          customPrompt: { value: 'Custom prompt' },
+        };
+        return settings[key] || null;
+      });
+
+      const result = settingsManager.getAll();
+
+      expect(result).toEqual({
+        defaultCodingTool: 'openai',
+        branchPrefix: 'feature-',
+        prTitlePrefix: '[FEATURE]',
+        commitSuffix: ' [done]',
+        commentPrefix: 'bot',
+        maxRetries: 5,
+        openaiApiKey: 'sk-test',
+        customPrompt: 'Custom prompt',
+      });
+    });
+
+    it('should mix default and custom values', () => {
+      mockDatabaseManager.getSetting.mockImplementation((key) => {
+        const settings: Record<string, any> = {
+          branchPrefix: { value: 'feature-' },
+          maxRetries: { value: '5' },
+        };
+        return settings[key] || null;
+      });
+
+      const result = settingsManager.getAll();
+
+      expect(result.branchPrefix).toBe('feature-');
+      expect(result.maxRetries).toBe(5);
+      expect(result.defaultCodingTool).toBe('amp'); // default
+      expect(result.prTitlePrefix).toBe('[DUCKLING]'); // default
+    });
+  });
+
+  describe('getDefaults', () => {
+    it('should return default settings', () => {
+      const defaults = SettingsManager.getDefaults();
+
+      expect(defaults).toEqual({
+        defaultCodingTool: 'amp',
+        branchPrefix: 'duckling-',
+        prTitlePrefix: '[DUCKLING]',
+        commitSuffix: ' [quack]',
+        commentPrefix: 'duckling',
+        maxRetries: 3,
+        openaiApiKey: '',
+        customPrompt: DEFAULT_CODING_PROMPT,
+      });
+    });
+
+    it('should return a copy of defaults', () => {
+      const defaults1 = SettingsManager.getDefaults();
+      const defaults2 = SettingsManager.getDefaults();
+
+      expect(defaults1).not.toBe(defaults2);
+      expect(defaults1).toEqual(defaults2);
+    });
+  });
+
+  describe('Type Safety', () => {
+    it('should enforce correct types', () => {
+      // These should compile without TypeScript errors
+      settingsManager.set('defaultCodingTool', 'amp');
+      settingsManager.set('defaultCodingTool', 'openai');
+      settingsManager.set('branchPrefix', 'feature-');
+      settingsManager.set('maxRetries', 5);
+
+      const codingTool = settingsManager.get('defaultCodingTool');
+      const branchPrefix = settingsManager.get('branchPrefix');
+      const maxRetries = settingsManager.get('maxRetries');
+
+      expect(typeof codingTool).toBe('string');
+      expect(typeof branchPrefix).toBe('string');
+      expect(typeof maxRetries).toBe('number');
+    });
+  });
+});

--- a/src/core/__tests__/task-executor.test.ts
+++ b/src/core/__tests__/task-executor.test.ts
@@ -1,0 +1,312 @@
+import { TaskExecutor, TaskOperation } from '../task-executor';
+import { logger } from '../../utils/logger';
+
+jest.mock('../../utils/logger');
+
+const mockLogger = logger as jest.Mocked<typeof logger>;
+
+describe('TaskExecutor', () => {
+  let taskExecutor: TaskExecutor;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    // Create a new instance for each test to avoid state pollution
+    (TaskExecutor as any).instance = undefined;
+    taskExecutor = TaskExecutor.getInstance();
+  });
+
+  describe('Singleton Pattern', () => {
+    it('should return the same instance', () => {
+      const instance1 = TaskExecutor.getInstance();
+      const instance2 = TaskExecutor.getInstance();
+      
+      expect(instance1).toBe(instance2);
+    });
+  });
+
+  describe('executeTask', () => {
+    it('should execute a task operation', async () => {
+      const mockExecute = jest.fn().mockResolvedValue(undefined);
+      const operation: TaskOperation = {
+        taskId: 1,
+        operation: 'test-operation',
+        execute: mockExecute,
+      };
+
+      await taskExecutor.executeTask(operation);
+
+      expect(mockExecute).toHaveBeenCalled();
+      expect(mockLogger.info).toHaveBeenCalledWith(
+        'Starting task operation: test-operation',
+        '1'
+      );
+      expect(mockLogger.info).toHaveBeenCalledWith(
+        'Completed task operation: test-operation',
+        '1'
+      );
+    });
+
+    it('should handle task operation failure', async () => {
+      const error = new Error('Task failed');
+      const mockExecute = jest.fn().mockRejectedValue(error);
+      const operation: TaskOperation = {
+        taskId: 1,
+        operation: 'test-operation',
+        execute: mockExecute,
+      };
+
+      await expect(taskExecutor.executeTask(operation)).rejects.toThrow('Task failed');
+
+      expect(mockExecute).toHaveBeenCalled();
+      // Wait for async processing
+      await new Promise(resolve => setTimeout(resolve, 0));
+      expect(mockLogger.error).toHaveBeenCalledWith(
+        'Failed task operation: test-operation - Error: Task failed',
+        '1'
+      );
+    });
+
+    it('should emit events during task execution', async () => {
+      const mockExecute = jest.fn().mockResolvedValue(undefined);
+      const operation: TaskOperation = {
+        taskId: 1,
+        operation: 'test-operation',
+        execute: mockExecute,
+      };
+
+      const startSpy = jest.fn();
+      const completeSpy = jest.fn();
+      taskExecutor.on('operation-start', startSpy);
+      taskExecutor.on('operation-complete', completeSpy);
+
+      await taskExecutor.executeTask(operation);
+
+      expect(startSpy).toHaveBeenCalledWith(expect.objectContaining({
+        taskId: 1,
+        operation: 'test-operation',
+      }));
+      expect(completeSpy).toHaveBeenCalledWith(expect.objectContaining({
+        taskId: 1,
+        operation: 'test-operation',
+      }));
+    });
+
+    it('should emit error event on failure', async () => {
+      const error = new Error('Task failed');
+      const mockExecute = jest.fn().mockRejectedValue(error);
+      const operation: TaskOperation = {
+        taskId: 1,
+        operation: 'test-operation',
+        execute: mockExecute,
+      };
+
+      const errorSpy = jest.fn();
+      taskExecutor.on('operation-error', errorSpy);
+
+      await expect(taskExecutor.executeTask(operation)).rejects.toThrow('Task failed');
+
+      // Wait for async processing
+      await new Promise(resolve => setTimeout(resolve, 0));
+      expect(errorSpy).toHaveBeenCalledWith(expect.objectContaining({
+        taskId: 1,
+        operation: 'test-operation',
+      }), error);
+    });
+  });
+
+  describe('Queue Management', () => {
+    it('should execute tasks in order', async () => {
+      const executionOrder: number[] = [];
+      const operation1: TaskOperation = {
+        taskId: 1,
+        operation: 'operation-1',
+        execute: async () => {
+          executionOrder.push(1);
+          await new Promise(resolve => setTimeout(resolve, 10));
+        },
+      };
+      const operation2: TaskOperation = {
+        taskId: 2,
+        operation: 'operation-2',
+        execute: async () => {
+          executionOrder.push(2);
+        },
+      };
+
+      // Start both operations
+      const promise1 = taskExecutor.executeTask(operation1);
+      const promise2 = taskExecutor.executeTask(operation2);
+
+      await Promise.all([promise1, promise2]);
+
+      expect(executionOrder).toEqual([1, 2]);
+    });
+
+    it('should not process multiple operations simultaneously', async () => {
+      let operation1Running = false;
+      let operation2Started = false;
+
+      const operation1: TaskOperation = {
+        taskId: 1,
+        operation: 'operation-1',
+        execute: async () => {
+          operation1Running = true;
+          await new Promise(resolve => setTimeout(resolve, 50));
+          operation1Running = false;
+        },
+      };
+
+      const operation2: TaskOperation = {
+        taskId: 2,
+        operation: 'operation-2',
+        execute: async () => {
+          operation2Started = true;
+          // Operation 2 should not start while operation 1 is running
+          expect(operation1Running).toBe(false);
+        },
+      };
+
+      const promise1 = taskExecutor.executeTask(operation1);
+      const promise2 = taskExecutor.executeTask(operation2);
+
+      await Promise.all([promise1, promise2]);
+
+      expect(operation2Started).toBe(true);
+    });
+  });
+
+  describe('State Management', () => {
+    it('should track current operation', async () => {
+      expect(taskExecutor.getCurrentOperation()).toBeNull();
+
+      const operation: TaskOperation = {
+        taskId: 1,
+        operation: 'test-operation',
+        execute: async () => {
+          expect(taskExecutor.getCurrentOperation()).toBeTruthy();
+          expect(taskExecutor.getCurrentOperation()?.taskId).toBe(1);
+        },
+      };
+
+      await taskExecutor.executeTask(operation);
+
+      expect(taskExecutor.getCurrentOperation()).toBeNull();
+    });
+
+    it('should track queued operations', () => {
+      const operation1: TaskOperation = {
+        taskId: 1,
+        operation: 'operation-1',
+        execute: async () => {
+          await new Promise(resolve => setTimeout(resolve, 100));
+        },
+      };
+
+      const operation2: TaskOperation = {
+        taskId: 2,
+        operation: 'operation-2',
+        execute: async () => {},
+      };
+
+      taskExecutor.executeTask(operation1);
+      taskExecutor.executeTask(operation2);
+
+      expect(taskExecutor.getQueueLength()).toBe(1); // operation1 is executing, operation2 is queued
+      expect(taskExecutor.getQueuedOperations()).toHaveLength(1);
+    });
+
+    it('should check if task is active', () => {
+      const operation1: TaskOperation = {
+        taskId: 1,
+        operation: 'operation-1',
+        execute: async () => {
+          await new Promise(resolve => setTimeout(resolve, 100));
+        },
+      };
+
+      const operation2: TaskOperation = {
+        taskId: 2,
+        operation: 'operation-2',
+        execute: async () => {},
+      };
+
+      taskExecutor.executeTask(operation1);
+      taskExecutor.executeTask(operation2);
+
+      expect(taskExecutor.isTaskActive(1)).toBe(true);
+      expect(taskExecutor.isTaskActive(2)).toBe(true);
+      expect(taskExecutor.isTaskActive(3)).toBe(false);
+    });
+  });
+
+  describe('Error Handling', () => {
+    it('should continue processing queue after error', async () => {
+      const operation1: TaskOperation = {
+        taskId: 1,
+        operation: 'failing-operation',
+        execute: async () => {
+          throw new Error('Operation failed');
+        },
+      };
+
+      const operation2: TaskOperation = {
+        taskId: 2,
+        operation: 'successful-operation',
+        execute: jest.fn().mockResolvedValue(undefined),
+      };
+
+      await expect(taskExecutor.executeTask(operation1)).rejects.toThrow('Operation failed');
+      await taskExecutor.executeTask(operation2);
+
+      expect(operation2.execute).toHaveBeenCalled();
+    });
+
+    it('should handle multiple errors', async () => {
+      const operation1: TaskOperation = {
+        taskId: 1,
+        operation: 'failing-operation-1',
+        execute: async () => {
+          throw new Error('Operation 1 failed');
+        },
+      };
+
+      const operation2: TaskOperation = {
+        taskId: 2,
+        operation: 'failing-operation-2',
+        execute: async () => {
+          throw new Error('Operation 2 failed');
+        },
+      };
+
+      await expect(taskExecutor.executeTask(operation1)).rejects.toThrow('Operation 1 failed');
+      await expect(taskExecutor.executeTask(operation2)).rejects.toThrow('Operation 2 failed');
+
+      // Wait for async processing
+      await new Promise(resolve => setTimeout(resolve, 0));
+      expect(mockLogger.error).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('Concurrent Operations', () => {
+    it('should handle multiple executeTask calls', async () => {
+      const operations: TaskOperation[] = [];
+      const promises: Promise<void>[] = [];
+
+      for (let i = 1; i <= 5; i++) {
+        const operation: TaskOperation = {
+          taskId: i,
+          operation: `operation-${i}`,
+          execute: jest.fn().mockResolvedValue(undefined),
+        };
+        operations.push(operation);
+        promises.push(taskExecutor.executeTask(operation));
+      }
+
+      await Promise.all(promises);
+
+      operations.forEach(op => {
+        expect(op.execute).toHaveBeenCalled();
+      });
+    });
+  });
+});

--- a/src/types/__tests__/index.test.ts
+++ b/src/types/__tests__/index.test.ts
@@ -1,0 +1,174 @@
+import {
+  Task,
+  TaskStatus,
+  CodingTool,
+  TaskLog,
+  LogLevel,
+  Setting,
+  PrecommitCheck,
+  Repository,
+  DucklingSettings,
+  TaskUpdateEvent,
+  ApiResponse,
+  CreateTaskRequest,
+} from '../index';
+
+describe('Types', () => {
+  describe('Task', () => {
+    it('should have correct structure', () => {
+      const task: Task = {
+        id: 1,
+        title: 'Test Task',
+        description: 'Test Description',
+        status: 'pending',
+        coding_tool: 'openai',
+        repository_path: '/test/path',
+        created_at: '2023-01-01T00:00:00Z',
+        updated_at: '2023-01-01T00:00:00Z',
+      };
+
+      expect(task).toHaveProperty('id');
+      expect(task).toHaveProperty('title');
+      expect(task).toHaveProperty('description');
+      expect(task).toHaveProperty('status');
+      expect(task).toHaveProperty('coding_tool');
+      expect(task).toHaveProperty('repository_path');
+      expect(task).toHaveProperty('created_at');
+      expect(task).toHaveProperty('updated_at');
+    });
+
+    it('should support optional fields', () => {
+      const task: Task = {
+        id: 1,
+        title: 'Test Task',
+        description: 'Test Description',
+        summary: 'Test Summary',
+        status: 'pending',
+        coding_tool: 'openai',
+        repository_path: '/test/path',
+        current_stage: 'analysis',
+        branch_name: 'test-branch',
+        pr_number: 123,
+        pr_url: 'https://github.com/test/repo/pull/123',
+        created_at: '2023-01-01T00:00:00Z',
+        updated_at: '2023-01-01T00:00:00Z',
+        completed_at: '2023-01-01T01:00:00Z',
+      };
+
+      expect(task.summary).toBe('Test Summary');
+      expect(task.current_stage).toBe('analysis');
+      expect(task.branch_name).toBe('test-branch');
+      expect(task.pr_number).toBe(123);
+      expect(task.pr_url).toBe('https://github.com/test/repo/pull/123');
+      expect(task.completed_at).toBe('2023-01-01T01:00:00Z');
+    });
+  });
+
+  describe('TaskStatus', () => {
+    it('should include all valid status values', () => {
+      const validStatuses: TaskStatus[] = [
+        'pending',
+        'in-progress',
+        'awaiting-review',
+        'addressing-review',
+        'completed',
+        'failed',
+        'cancelled',
+      ];
+
+      validStatuses.forEach(status => {
+        expect(typeof status).toBe('string');
+      });
+    });
+  });
+
+  describe('CodingTool', () => {
+    it('should include all valid coding tools', () => {
+      const validTools: CodingTool[] = ['openai', 'amp'];
+
+      validTools.forEach(tool => {
+        expect(typeof tool).toBe('string');
+      });
+    });
+  });
+
+  describe('TaskLog', () => {
+    it('should have correct structure', () => {
+      const taskLog: TaskLog = {
+        id: 1,
+        task_id: 1,
+        level: 'info',
+        message: 'Test log message',
+        timestamp: '2023-01-01T00:00:00Z',
+      };
+
+      expect(taskLog).toHaveProperty('id');
+      expect(taskLog).toHaveProperty('task_id');
+      expect(taskLog).toHaveProperty('level');
+      expect(taskLog).toHaveProperty('message');
+      expect(taskLog).toHaveProperty('timestamp');
+    });
+  });
+
+  describe('LogLevel', () => {
+    it('should include all valid log levels', () => {
+      const validLevels: LogLevel[] = ['info', 'error', 'debug', 'warn'];
+
+      validLevels.forEach(level => {
+        expect(typeof level).toBe('string');
+      });
+    });
+  });
+
+  describe('ApiResponse', () => {
+    it('should handle success response', () => {
+      const response: ApiResponse<string> = {
+        success: true,
+        data: 'test data',
+      };
+
+      expect(response.success).toBe(true);
+      expect(response.data).toBe('test data');
+    });
+
+    it('should handle error response', () => {
+      const response: ApiResponse = {
+        success: false,
+        error: 'test error',
+      };
+
+      expect(response.success).toBe(false);
+      expect(response.error).toBe('test error');
+    });
+  });
+
+  describe('CreateTaskRequest', () => {
+    it('should have correct structure', () => {
+      const request: CreateTaskRequest = {
+        title: 'Test Task',
+        description: 'Test Description',
+        codingTool: 'openai',
+        repositoryPath: '/test/path',
+      };
+
+      expect(request).toHaveProperty('title');
+      expect(request).toHaveProperty('description');
+      expect(request).toHaveProperty('codingTool');
+      expect(request).toHaveProperty('repositoryPath');
+    });
+
+    it('should support optional fields', () => {
+      const request: CreateTaskRequest = {
+        title: 'Test Task',
+        description: 'Test Description',
+        codingTool: 'openai',
+        repositoryPath: '/test/path',
+        branchPrefix: 'feature/',
+        prPrefix: '[FEATURE]',
+      };
+
+      expect(request.branchPrefix).toBe('feature/');
+      expect(request.prPrefix).toBe('[FEATURE]');
+    });
+  });
+});

--- a/src/utils/__tests__/comment-processor.test.ts
+++ b/src/utils/__tests__/comment-processor.test.ts
@@ -1,0 +1,278 @@
+import { 
+  extractDucklingComments, 
+  shouldProcessComment, 
+  processComment 
+} from '../comment-processor';
+
+describe('Comment Processor', () => {
+  describe('extractDucklingComments', () => {
+    it('should extract duckling comments with default prefix', () => {
+      const comments = [
+        {
+          id: 1,
+          body: 'duckling: please fix the bug',
+          author: { login: 'user1' },
+          createdAt: '2023-01-01T00:00:00Z',
+        },
+        {
+          id: 2,
+          body: 'This is a regular comment',
+          author: { login: 'user2' },
+          createdAt: '2023-01-02T00:00:00Z',
+        },
+        {
+          id: 3,
+          body: 'duckling: add new feature',
+          author: { login: 'user3' },
+          createdAt: '2023-01-03T00:00:00Z',
+        },
+      ];
+
+      const result = extractDucklingComments(comments);
+
+      expect(result).toHaveLength(2);
+      expect(result[0]).toEqual({
+        id: 1,
+        body: 'duckling: please fix the bug',
+        author: { login: 'user1' },
+        createdAt: '2023-01-01T00:00:00Z',
+      });
+      expect(result[1]).toEqual({
+        id: 3,
+        body: 'duckling: add new feature',
+        author: { login: 'user3' },
+        createdAt: '2023-01-03T00:00:00Z',
+      });
+    });
+
+    it('should extract comments with custom prefix', () => {
+      const comments = [
+        {
+          id: 1,
+          body: 'bot: please fix the bug',
+          author: { login: 'user1' },
+          createdAt: '2023-01-01T00:00:00Z',
+        },
+        {
+          id: 2,
+          body: 'duckling: should be ignored',
+          author: { login: 'user2' },
+          createdAt: '2023-01-02T00:00:00Z',
+        },
+      ];
+
+      const result = extractDucklingComments(comments, 'bot');
+
+      expect(result).toHaveLength(1);
+      expect(result[0].body).toBe('bot: please fix the bug');
+    });
+
+    it('should handle case-insensitive matching', () => {
+      const comments = [
+        {
+          id: 1,
+          body: 'DUCKLING: uppercase comment',
+          author: { login: 'user1' },
+          createdAt: '2023-01-01T00:00:00Z',
+        },
+        {
+          id: 2,
+          body: 'Duckling: title case comment',
+          author: { login: 'user2' },
+          createdAt: '2023-01-02T00:00:00Z',
+        },
+      ];
+
+      const result = extractDucklingComments(comments);
+
+      expect(result).toHaveLength(2);
+    });
+
+    it('should handle comments with prefix in middle of text', () => {
+      const comments = [
+        {
+          id: 1,
+          body: 'Please duckling: fix this bug',
+          author: { login: 'user1' },
+          createdAt: '2023-01-01T00:00:00Z',
+        },
+        {
+          id: 2,
+          body: 'duckling: at the start',
+          author: { login: 'user2' },
+          createdAt: '2023-01-02T00:00:00Z',
+        },
+      ];
+
+      const result = extractDucklingComments(comments);
+
+      expect(result).toHaveLength(2);
+    });
+
+    it('should handle empty comments array', () => {
+      const result = extractDucklingComments([]);
+
+      expect(result).toHaveLength(0);
+    });
+
+    it('should handle comments without body', () => {
+      const comments = [
+        {
+          id: 1,
+          body: '',
+          author: { login: 'user1' },
+          createdAt: '2023-01-01T00:00:00Z',
+        },
+        {
+          id: 2,
+          body: null as any,
+          author: { login: 'user2' },
+          createdAt: '2023-01-02T00:00:00Z',
+        },
+      ];
+
+      const result = extractDucklingComments(comments);
+
+      expect(result).toHaveLength(0);
+    });
+  });
+
+  describe('shouldProcessComment', () => {
+    it('should return true for new comments', () => {
+      const result = shouldProcessComment(
+        { id: 1, body: 'duckling: test', author: { login: 'user1' }, createdAt: '2023-01-01T00:00:00Z' },
+        []
+      );
+
+      expect(result).toBe(true);
+    });
+
+    it('should return false for already processed comments', () => {
+      const comment = { id: 1, body: 'duckling: test', author: { login: 'user1' }, createdAt: '2023-01-01T00:00:00Z' };
+      const processed = [1, 2, 3];
+
+      const result = shouldProcessComment(comment, processed);
+
+      expect(result).toBe(false);
+    });
+
+    it('should return true for comments not in processed list', () => {
+      const comment = { id: 4, body: 'duckling: test', author: { login: 'user1' }, createdAt: '2023-01-01T00:00:00Z' };
+      const processed = [1, 2, 3];
+
+      const result = shouldProcessComment(comment, processed);
+
+      expect(result).toBe(true);
+    });
+  });
+
+  describe('processComment', () => {
+    it('should extract task from comment body', () => {
+      const comment = {
+        id: 1,
+        body: 'duckling: please fix the authentication bug in the login module',
+        author: { login: 'user1' },
+        createdAt: '2023-01-01T00:00:00Z',
+      };
+
+      const result = processComment(comment);
+
+      expect(result).toEqual({
+        commentId: 1,
+        task: 'please fix the authentication bug in the login module',
+        author: 'user1',
+        createdAt: '2023-01-01T00:00:00Z',
+      });
+    });
+
+    it('should handle comment with custom prefix', () => {
+      const comment = {
+        id: 2,
+        body: 'bot: add new feature to the dashboard',
+        author: { login: 'user2' },
+        createdAt: '2023-01-02T00:00:00Z',
+      };
+
+      const result = processComment(comment, 'bot');
+
+      expect(result).toEqual({
+        commentId: 2,
+        task: 'add new feature to the dashboard',
+        author: 'user2',
+        createdAt: '2023-01-02T00:00:00Z',
+      });
+    });
+
+    it('should handle comment with multiple colons', () => {
+      const comment = {
+        id: 3,
+        body: 'duckling: fix the bug: it should work correctly',
+        author: { login: 'user3' },
+        createdAt: '2023-01-03T00:00:00Z',
+      };
+
+      const result = processComment(comment);
+
+      expect(result).toEqual({
+        commentId: 3,
+        task: 'fix the bug: it should work correctly',
+        author: 'user3',
+        createdAt: '2023-01-03T00:00:00Z',
+      });
+    });
+
+    it('should handle comment without colon', () => {
+      const comment = {
+        id: 4,
+        body: 'duckling please fix this',
+        author: { login: 'user4' },
+        createdAt: '2023-01-04T00:00:00Z',
+      };
+
+      const result = processComment(comment);
+
+      expect(result).toEqual({
+        commentId: 4,
+        task: 'duckling please fix this',
+        author: 'user4',
+        createdAt: '2023-01-04T00:00:00Z',
+      });
+    });
+
+    it('should trim whitespace from task', () => {
+      const comment = {
+        id: 5,
+        body: 'duckling:   fix the spacing issue   ',
+        author: { login: 'user5' },
+        createdAt: '2023-01-05T00:00:00Z',
+      };
+
+      const result = processComment(comment);
+
+      expect(result).toEqual({
+        commentId: 5,
+        task: 'fix the spacing issue',
+        author: 'user5',
+        createdAt: '2023-01-05T00:00:00Z',
+      });
+    });
+
+    it('should handle empty task after prefix', () => {
+      const comment = {
+        id: 6,
+        body: 'duckling:',
+        author: { login: 'user6' },
+        createdAt: '2023-01-06T00:00:00Z',
+      };
+
+      const result = processComment(comment);
+
+      expect(result).toEqual({
+        commentId: 6,
+        task: '',
+        author: 'user6',
+        createdAt: '2023-01-06T00:00:00Z',
+      });
+    });
+  });
+});

--- a/src/utils/__tests__/constants.test.ts
+++ b/src/utils/__tests__/constants.test.ts
@@ -1,0 +1,93 @@
+import path from 'path';
+import os from 'os';
+import {
+  APP_NAME,
+  DEFAULT_PORT,
+  DUCKLING_DIR,
+  DATABASE_PATH,
+  LOGS_DIR,
+  CODING_TOOLS,
+  DEFAULT_SETTINGS,
+  LOG_LEVELS,
+} from '../constants';
+
+describe('Constants', () => {
+  describe('App Configuration', () => {
+    it('should have correct app name', () => {
+      expect(APP_NAME).toBe('duckling');
+    });
+
+    it('should have correct default port', () => {
+      expect(DEFAULT_PORT).toBe(5050);
+    });
+  });
+
+  describe('Paths', () => {
+    it('should have correct duckling directory', () => {
+      expect(DUCKLING_DIR).toBe(path.join(os.homedir(), '.duckling'));
+    });
+
+    it('should have correct database path', () => {
+      expect(DATABASE_PATH).toBe(path.join(DUCKLING_DIR, 'duckling.db'));
+    });
+
+    it('should have correct logs directory', () => {
+      expect(LOGS_DIR).toBe(path.join(DUCKLING_DIR, 'logs'));
+    });
+  });
+
+  describe('Coding Tools', () => {
+    it('should include all supported coding tools', () => {
+      expect(CODING_TOOLS).toEqual(['amp', 'openai']);
+    });
+
+    it('should be readonly array', () => {
+      expect(CODING_TOOLS).toHaveLength(2);
+      expect(Array.isArray(CODING_TOOLS)).toBe(true);
+      // In TypeScript, const assertions create readonly arrays,
+      // but at runtime they're still mutable arrays
+      expect(CODING_TOOLS).toEqual(['amp', 'openai']);
+    });
+  });
+
+  describe('Default Settings', () => {
+    it('should have correct branch prefix', () => {
+      expect(DEFAULT_SETTINGS.branchPrefix).toBe('duckling-');
+    });
+
+    it('should have correct PR title prefix', () => {
+      expect(DEFAULT_SETTINGS.prTitlePrefix).toBe('[DUCKLING]');
+    });
+
+    it('should have correct commit suffix', () => {
+      expect(DEFAULT_SETTINGS.commitSuffix).toBe(' [quack]');
+    });
+
+    it('should have correct comment prefix', () => {
+      expect(DEFAULT_SETTINGS.commentPrefix).toBe('duckling');
+    });
+
+    it('should have correct max retries', () => {
+      expect(DEFAULT_SETTINGS.maxRetries).toBe(3);
+    });
+
+    it('should have custom prompt', () => {
+      expect(DEFAULT_SETTINGS.customPrompt).toBeDefined();
+      expect(typeof DEFAULT_SETTINGS.customPrompt).toBe('string');
+    });
+  });
+
+  describe('Log Levels', () => {
+    it('should include all log levels', () => {
+      expect(LOG_LEVELS).toEqual(['debug', 'info', 'warn', 'error']);
+    });
+
+    it('should be readonly array', () => {
+      expect(LOG_LEVELS).toHaveLength(4);
+      expect(Array.isArray(LOG_LEVELS)).toBe(true);
+      // In TypeScript, const assertions create readonly arrays,
+      // but at runtime they're still mutable arrays
+      expect(LOG_LEVELS).toEqual(['debug', 'info', 'warn', 'error']);
+    });
+  });
+});

--- a/src/utils/__tests__/exec.test.ts
+++ b/src/utils/__tests__/exec.test.ts
@@ -1,0 +1,204 @@
+import { execa } from 'execa';
+import { execCommand, execCommandWithInputStreaming, execCommandStreaming, execShellCommand } from '../exec';
+import { logger } from '../logger';
+
+jest.mock('execa');
+jest.mock('../logger');
+
+const mockExeca = execa as jest.MockedFunction<typeof execa>;
+const mockLogger = logger as jest.Mocked<typeof logger>;
+
+describe('Exec Utilities', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('execCommand', () => {
+    it('should execute command and return result', async () => {
+      const mockResult = {
+        stdout: 'test output',
+        stderr: '',
+        exitCode: 0,
+      };
+
+      mockExeca.mockResolvedValue(mockResult as any);
+
+      const result = await execCommand('ls', ['-la']);
+
+      expect(result).toEqual(mockResult);
+      expect(mockExeca).toHaveBeenCalledWith('ls', ['-la'], {
+        reject: false,
+      });
+      expect(mockLogger.logCommand).toHaveBeenCalledWith('ls', ['-la'], process.cwd(), undefined);
+      expect(mockLogger.logCommandResult).toHaveBeenCalledWith('ls', 0, 'test output', '', undefined);
+    });
+
+    it('should handle command with options', async () => {
+      const mockResult = {
+        stdout: 'test output',
+        stderr: '',
+        exitCode: 0,
+      };
+
+      mockExeca.mockResolvedValue(mockResult as any);
+
+      const result = await execCommand('ls', ['-la'], { cwd: '/test', taskId: 'task-1' });
+
+      expect(result).toEqual(mockResult);
+      expect(mockExeca).toHaveBeenCalledWith('ls', ['-la'], {
+        reject: false,
+        cwd: '/test',
+      });
+      expect(mockLogger.logCommand).toHaveBeenCalledWith('ls', ['-la'], '/test', 'task-1');
+      expect(mockLogger.logCommandResult).toHaveBeenCalledWith('ls', 0, 'test output', '', 'task-1');
+    });
+
+    it('should handle command failure', async () => {
+      const mockError = new Error('Command failed');
+      (mockError as any).exitCode = 1;
+      (mockError as any).stdout = 'error output';
+      (mockError as any).stderr = 'error message';
+
+      mockExeca.mockRejectedValue(mockError);
+
+      await expect(execCommand('ls', ['-la'])).rejects.toThrow('Command failed');
+      expect(mockLogger.logCommandResult).toHaveBeenCalledWith('ls', 1, 'error output', 'error message', undefined);
+    });
+
+    it('should handle command with non-zero exit code', async () => {
+      const mockResult = {
+        stdout: 'test output',
+        stderr: 'warning',
+        exitCode: 1,
+      };
+
+      mockExeca.mockResolvedValue(mockResult as any);
+
+      const result = await execCommand('ls', ['-la']);
+
+      expect(result).toEqual(mockResult);
+      expect(mockLogger.logCommandResult).toHaveBeenCalledWith('ls', 1, 'test output', 'warning', undefined);
+    });
+  });
+
+  describe('execCommandWithInputStreaming', () => {
+    it('should execute command with input streaming', async () => {
+      const mockSubprocess = {
+        stdout: {
+          on: jest.fn(),
+        },
+        stderr: {
+          on: jest.fn(),
+        },
+        exitCode: 0,
+      };
+
+      mockExeca.mockReturnValue(mockSubprocess as any);
+
+      const promise = execCommandWithInputStreaming('cat', 'test input', []);
+
+      // Simulate the subprocess resolving
+      setTimeout(() => {
+        mockSubprocess.stdout.on.mock.calls.forEach(([event, callback]) => {
+          if (event === 'data') {
+            callback(Buffer.from('test output'));
+          }
+        });
+      }, 0);
+
+      // Mock the subprocess promise resolution
+      const mockResult = Promise.resolve(mockSubprocess);
+      mockExeca.mockReturnValue(mockResult as any);
+
+      const result = await execCommandWithInputStreaming('cat', 'test input', []);
+
+      expect(mockExeca).toHaveBeenCalledWith('cat', [], {
+        reject: false,
+        input: 'test input',
+        stdio: 'pipe',
+      });
+      expect(mockLogger.logCommand).toHaveBeenCalledWith('cat', [], process.cwd(), undefined);
+    });
+
+    it('should handle streaming with taskId', async () => {
+      const mockSubprocess = {
+        stdout: {
+          on: jest.fn(),
+        },
+        stderr: {
+          on: jest.fn(),
+        },
+        exitCode: 0,
+      };
+
+      mockExeca.mockReturnValue(Promise.resolve(mockSubprocess) as any);
+
+      await execCommandWithInputStreaming('cat', 'test input', [], { taskId: 'task-1' });
+
+      expect(mockLogger.logCommand).toHaveBeenCalledWith('cat', [], process.cwd(), 'task-1');
+    });
+  });
+
+  describe('execCommandStreaming', () => {
+    it('should execute command with streaming', async () => {
+      const mockSubprocess = {
+        stdout: {
+          on: jest.fn(),
+        },
+        stderr: {
+          on: jest.fn(),
+        },
+        exitCode: 0,
+      };
+
+      mockExeca.mockReturnValue(Promise.resolve(mockSubprocess) as any);
+
+      const result = await execCommandStreaming('ls', ['-la']);
+
+      expect(mockExeca).toHaveBeenCalledWith('ls', ['-la'], {
+        reject: false,
+        stdio: 'pipe',
+      });
+      expect(mockLogger.logCommand).toHaveBeenCalledWith('ls', ['-la'], process.cwd(), undefined);
+    });
+  });
+
+  describe('execShellCommand', () => {
+    it('should execute shell command', async () => {
+      const mockResult = {
+        stdout: 'test output',
+        stderr: '',
+        exitCode: 0,
+      };
+
+      mockExeca.mockResolvedValue(mockResult as any);
+
+      const result = await execShellCommand('ls -la');
+
+      expect(result).toEqual(mockResult);
+      expect(mockExeca).toHaveBeenCalledWith('bash', ['-c', 'ls -la'], {
+        reject: false,
+      });
+      expect(mockLogger.logCommand).toHaveBeenCalledWith('bash', ['-c', 'ls -la'], process.cwd(), undefined);
+    });
+
+    it('should handle shell command with options', async () => {
+      const mockResult = {
+        stdout: 'test output',
+        stderr: '',
+        exitCode: 0,
+      };
+
+      mockExeca.mockResolvedValue(mockResult as any);
+
+      const result = await execShellCommand('ls -la', { cwd: '/test', taskId: 'task-1' });
+
+      expect(result).toEqual(mockResult);
+      expect(mockExeca).toHaveBeenCalledWith('bash', ['-c', 'ls -la'], {
+        reject: false,
+        cwd: '/test',
+      });
+      expect(mockLogger.logCommand).toHaveBeenCalledWith('bash', ['-c', 'ls -la'], '/test', 'task-1');
+    });
+  });
+});

--- a/src/utils/__tests__/git-utils.test.ts
+++ b/src/utils/__tests__/git-utils.test.ts
@@ -1,0 +1,124 @@
+import { validateAndGetRepoInfo } from '../git-utils';
+import { simpleGit } from 'simple-git';
+import { logger } from '../logger';
+
+jest.mock('simple-git');
+jest.mock('../logger');
+
+const mockSimpleGit = simpleGit as jest.MockedFunction<typeof simpleGit>;
+const mockLogger = logger as jest.Mocked<typeof logger>;
+
+describe('Git Utils', () => {
+  let mockGit: any;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGit = {
+      checkIsRepo: jest.fn(),
+      getRemotes: jest.fn(),
+    };
+    mockSimpleGit.mockReturnValue(mockGit);
+  });
+
+  describe('validateAndGetRepoInfo', () => {
+    it('should validate and return repo info for valid GitHub repository', async () => {
+      mockGit.checkIsRepo.mockResolvedValue(true);
+      mockGit.getRemotes.mockResolvedValue([
+        {
+          name: 'origin',
+          refs: {
+            fetch: 'https://github.com/testuser/testrepo.git',
+          },
+        },
+      ]);
+
+      const result = await validateAndGetRepoInfo('/test/path');
+
+      expect(result).toEqual({
+        repoPath: '/test/path',
+        remoteUrl: 'https://github.com/testuser/testrepo',
+        owner: 'testuser',
+        name: 'testrepo',
+      });
+      expect(mockLogger.info).toHaveBeenCalledWith('Git repository validated: testuser/testrepo');
+    });
+
+    it('should handle SSH GitHub URL', async () => {
+      mockGit.checkIsRepo.mockResolvedValue(true);
+      mockGit.getRemotes.mockResolvedValue([
+        {
+          name: 'origin',
+          refs: {
+            fetch: 'git@github.com:testuser/testrepo.git',
+          },
+        },
+      ]);
+
+      const result = await validateAndGetRepoInfo('/test/path');
+
+      expect(result).toEqual({
+        repoPath: '/test/path',
+        remoteUrl: 'git@github.com:testuser/testrepo',
+        owner: 'testuser',
+        name: 'testrepo',
+      });
+    });
+
+    it('should throw error for non-git repository', async () => {
+      mockGit.checkIsRepo.mockResolvedValue(false);
+
+      await expect(validateAndGetRepoInfo('/test/path')).rejects.toThrow(
+        'Directory /test/path is not a git repository. Please run duckling from within a git repository.'
+      );
+      expect(mockLogger.error).toHaveBeenCalledWith(
+        'Git repository validation failed: Directory /test/path is not a git repository. Please run duckling from within a git repository.'
+      );
+    });
+
+    it('should throw error when no origin remote found', async () => {
+      mockGit.checkIsRepo.mockResolvedValue(true);
+      mockGit.getRemotes.mockResolvedValue([]);
+
+      await expect(validateAndGetRepoInfo('/test/path')).rejects.toThrow(
+        'No origin remote found. Please ensure the repository has a GitHub origin remote.'
+      );
+    });
+
+    it('should throw error when origin has no fetch URL', async () => {
+      mockGit.checkIsRepo.mockResolvedValue(true);
+      mockGit.getRemotes.mockResolvedValue([
+        {
+          name: 'origin',
+          refs: {},
+        },
+      ]);
+
+      await expect(validateAndGetRepoInfo('/test/path')).rejects.toThrow(
+        'No origin remote found. Please ensure the repository has a GitHub origin remote.'
+      );
+    });
+
+    it('should throw error for non-GitHub remote', async () => {
+      mockGit.checkIsRepo.mockResolvedValue(true);
+      mockGit.getRemotes.mockResolvedValue([
+        {
+          name: 'origin',
+          refs: {
+            fetch: 'https://gitlab.com/testuser/testrepo.git',
+          },
+        },
+      ]);
+
+      await expect(validateAndGetRepoInfo('/test/path')).rejects.toThrow(
+        'Origin remote is not a GitHub repository. Please ensure you are working with a GitHub repository.'
+      );
+    });
+
+    it('should handle git errors', async () => {
+      mockGit.checkIsRepo.mockRejectedValue(new Error('Git error'));
+
+      await expect(validateAndGetRepoInfo('/test/path')).rejects.toThrow('Git error');
+      expect(mockLogger.error).toHaveBeenCalledWith('Git repository validation failed: Git error');
+    });
+  });
+});

--- a/src/utils/__tests__/github-cli-utils.test.ts
+++ b/src/utils/__tests__/github-cli-utils.test.ts
@@ -1,0 +1,180 @@
+import { 
+  getGitHubRepoInfo, 
+  createPullRequest, 
+  addPullRequestComment, 
+  getPullRequestComments 
+} from '../github-cli-utils';
+import { exec } from '../exec';
+
+jest.mock('../exec');
+
+const mockExec = exec as jest.MockedFunction<typeof exec>;
+
+describe('GitHub CLI Utils', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('getGitHubRepoInfo', () => {
+    it('should return repository info', async () => {
+      mockExec.mockResolvedValue({
+        stdout: '{"owner":"testuser","name":"testrepo","url":"https://github.com/testuser/testrepo"}\n',
+        stderr: '',
+        exitCode: 0,
+      });
+
+      const info = await getGitHubRepoInfo();
+
+      expect(info).toEqual({
+        owner: 'testuser',
+        name: 'testrepo',
+        url: 'https://github.com/testuser/testrepo',
+      });
+      expect(mockExec).toHaveBeenCalledWith('gh repo view --json owner,name,url');
+    });
+
+    it('should handle invalid JSON response', async () => {
+      mockExec.mockResolvedValue({
+        stdout: 'invalid json',
+        stderr: '',
+        exitCode: 0,
+      });
+
+      await expect(getGitHubRepoInfo()).rejects.toThrow();
+    });
+
+    it('should handle command failure', async () => {
+      mockExec.mockRejectedValue(new Error('GitHub CLI not authenticated'));
+
+      await expect(getGitHubRepoInfo()).rejects.toThrow('GitHub CLI not authenticated');
+    });
+  });
+
+  describe('createPullRequest', () => {
+    it('should create a pull request', async () => {
+      mockExec.mockResolvedValue({
+        stdout: 'https://github.com/testuser/testrepo/pull/123\n',
+        stderr: '',
+        exitCode: 0,
+      });
+
+      const url = await createPullRequest('Test PR', 'Test description', 'feature-branch', 'main');
+
+      expect(url).toBe('https://github.com/testuser/testrepo/pull/123');
+      expect(mockExec).toHaveBeenCalledWith(
+        'gh pr create --title "Test PR" --body "Test description" --head feature-branch --base main'
+      );
+    });
+
+    it('should handle special characters in title and body', async () => {
+      mockExec.mockResolvedValue({
+        stdout: 'https://github.com/testuser/testrepo/pull/124\n',
+        stderr: '',
+        exitCode: 0,
+      });
+
+      const url = await createPullRequest('Fix: "bug" with \\'quotes\\'', 'Description with\nnewlines', 'fix-branch', 'main');
+
+      expect(url).toBe('https://github.com/testuser/testrepo/pull/124');
+      expect(mockExec).toHaveBeenCalledWith(
+        'gh pr create --title "Fix: \\"bug\\" with \'quotes\'" --body "Description with\nnewlines" --head fix-branch --base main'
+      );
+    });
+
+    it('should handle PR creation failure', async () => {
+      mockExec.mockRejectedValue(new Error('PR creation failed'));
+
+      await expect(createPullRequest('Test', 'Description', 'branch', 'main')).rejects.toThrow('PR creation failed');
+    });
+  });
+
+  describe('addPullRequestComment', () => {
+    it('should add a comment to a pull request', async () => {
+      mockExec.mockResolvedValue({
+        stdout: 'Comment added successfully\n',
+        stderr: '',
+        exitCode: 0,
+      });
+
+      await addPullRequestComment(123, 'Test comment');
+
+      expect(mockExec).toHaveBeenCalledWith('gh pr comment 123 --body "Test comment"');
+    });
+
+    it('should handle comments with special characters', async () => {
+      mockExec.mockResolvedValue({
+        stdout: 'Comment added successfully\n',
+        stderr: '',
+        exitCode: 0,
+      });
+
+      await addPullRequestComment(123, 'Comment with "quotes" and newlines\nSecond line');
+
+      expect(mockExec).toHaveBeenCalledWith('gh pr comment 123 --body "Comment with \\"quotes\\" and newlines\nSecond line"');
+    });
+
+    it('should handle comment addition failure', async () => {
+      mockExec.mockRejectedValue(new Error('Comment addition failed'));
+
+      await expect(addPullRequestComment(123, 'Test comment')).rejects.toThrow('Comment addition failed');
+    });
+  });
+
+  describe('getPullRequestComments', () => {
+    it('should get pull request comments', async () => {
+      const mockComments = [
+        {
+          id: 1,
+          body: 'First comment',
+          author: { login: 'user1' },
+          createdAt: '2023-01-01T00:00:00Z',
+        },
+        {
+          id: 2,
+          body: 'Second comment',
+          author: { login: 'user2' },
+          createdAt: '2023-01-02T00:00:00Z',
+        },
+      ];
+
+      mockExec.mockResolvedValue({
+        stdout: JSON.stringify(mockComments),
+        stderr: '',
+        exitCode: 0,
+      });
+
+      const comments = await getPullRequestComments(123);
+
+      expect(comments).toEqual(mockComments);
+      expect(mockExec).toHaveBeenCalledWith('gh pr view 123 --json comments --jq .comments');
+    });
+
+    it('should handle empty comments', async () => {
+      mockExec.mockResolvedValue({
+        stdout: '[]',
+        stderr: '',
+        exitCode: 0,
+      });
+
+      const comments = await getPullRequestComments(123);
+
+      expect(comments).toEqual([]);
+    });
+
+    it('should handle invalid JSON response', async () => {
+      mockExec.mockResolvedValue({
+        stdout: 'invalid json',
+        stderr: '',
+        exitCode: 0,
+      });
+
+      await expect(getPullRequestComments(123)).rejects.toThrow();
+    });
+
+    it('should handle command failure', async () => {
+      mockExec.mockRejectedValue(new Error('Failed to get comments'));
+
+      await expect(getPullRequestComments(123)).rejects.toThrow('Failed to get comments');
+    });
+  });
+});

--- a/src/utils/__tests__/logger.test.ts
+++ b/src/utils/__tests__/logger.test.ts
@@ -1,0 +1,183 @@
+import fs from 'fs';
+import path from 'path';
+
+jest.mock('fs');
+jest.mock('path');
+jest.mock('../constants', () => ({
+  LOGS_DIR: '/mock/logs',
+}));
+
+const mockFs = fs as jest.Mocked<typeof fs>;
+const mockPath = path as jest.Mocked<typeof path>;
+
+// Import logger after mocks are set up
+import { Logger, logger } from '../logger';
+
+describe('Logger', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockFs.existsSync.mockReturnValue(true);
+    mockFs.mkdirSync.mockReturnValue(undefined);
+    mockFs.appendFileSync.mockReturnValue(undefined);
+    mockPath.join.mockImplementation((...args) => args.join('/'));
+    
+    // Mock console.log to avoid test output
+    jest.spyOn(console, 'log').mockImplementation();
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe('Constructor', () => {
+    it('should create logs directory if it does not exist', () => {
+      mockFs.existsSync.mockReturnValue(false);
+      
+      new Logger();
+      
+      expect(mockFs.mkdirSync).toHaveBeenCalledWith('/mock/logs', { recursive: true });
+    });
+
+    it('should not create logs directory if it already exists', () => {
+      mockFs.existsSync.mockReturnValue(true);
+      
+      new Logger();
+      
+      expect(mockFs.mkdirSync).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Singleton Pattern', () => {
+    it('should return the same instance', () => {
+      const instance1 = Logger.getInstance();
+      const instance2 = Logger.getInstance();
+      
+      expect(instance1).toBe(instance2);
+    });
+  });
+
+  describe('Log Methods', () => {
+    beforeEach(() => {
+      jest.spyOn(Date.prototype, 'toISOString').mockReturnValue('2023-01-01T12:00:00.000Z');
+    });
+
+    it('should log debug message', () => {
+      logger.debug('Test debug message');
+      
+      expect(console.log).toHaveBeenCalledWith(
+        '[2023-01-01T12:00:00.000Z] [DEBUG] Test debug message'
+      );
+      expect(mockFs.appendFileSync).toHaveBeenCalledWith(
+        'duckling-2023-01-01.log',
+        '[2023-01-01T12:00:00.000Z] [DEBUG] Test debug message\n'
+      );
+    });
+
+    it('should log info message', () => {
+      logger.info('Test info message');
+      
+      expect(console.log).toHaveBeenCalledWith(
+        '[2023-01-01T12:00:00.000Z] [INFO] Test info message'
+      );
+      expect(mockFs.appendFileSync).toHaveBeenCalledWith(
+        'duckling-2023-01-01.log',
+        '[2023-01-01T12:00:00.000Z] [INFO] Test info message\n'
+      );
+    });
+
+    it('should log warn message', () => {
+      logger.warn('Test warn message');
+      
+      expect(console.log).toHaveBeenCalledWith(
+        '[2023-01-01T12:00:00.000Z] [WARN] Test warn message'
+      );
+      expect(mockFs.appendFileSync).toHaveBeenCalledWith(
+        'duckling-2023-01-01.log',
+        '[2023-01-01T12:00:00.000Z] [WARN] Test warn message\n'
+      );
+    });
+
+    it('should log error message', () => {
+      logger.error('Test error message');
+      
+      expect(console.log).toHaveBeenCalledWith(
+        '[2023-01-01T12:00:00.000Z] [ERROR] Test error message'
+      );
+      expect(mockFs.appendFileSync).toHaveBeenCalledWith(
+        'duckling-2023-01-01.log',
+        '[2023-01-01T12:00:00.000Z] [ERROR] Test error message\n'
+      );
+    });
+
+    it('should log message with taskId', () => {
+      logger.info('Test message', 'task-123');
+      
+      expect(console.log).toHaveBeenCalledWith(
+        '[2023-01-01T12:00:00.000Z] [INFO] [task-123] Test message'
+      );
+      expect(mockFs.appendFileSync).toHaveBeenCalledWith(
+        'duckling-2023-01-01.log',
+        '[2023-01-01T12:00:00.000Z] [INFO] [task-123] Test message\n'
+      );
+      expect(mockFs.appendFileSync).toHaveBeenCalledWith(
+        'task-task-123.log',
+        '[2023-01-01T12:00:00.000Z] [INFO] [task-123] Test message\n'
+      );
+    });
+  });
+
+  describe('Command Logging', () => {
+    beforeEach(() => {
+      jest.spyOn(Date.prototype, 'toISOString').mockReturnValue('2023-01-01T12:00:00.000Z');
+    });
+
+    it('should log command execution', () => {
+      logger.logCommand('git', ['status'], '/test/path');
+      
+      expect(console.log).toHaveBeenCalledWith(
+        '[2023-01-01T12:00:00.000Z] [INFO] Executing: git status (cwd: /test/path)'
+      );
+    });
+
+    it('should log command execution with taskId', () => {
+      logger.logCommand('git', ['status'], '/test/path', 'task-123');
+      
+      expect(console.log).toHaveBeenCalledWith(
+        '[2023-01-01T12:00:00.000Z] [INFO] [task-123] Executing: git status (cwd: /test/path)'
+      );
+    });
+
+    it('should log successful command result', () => {
+      logger.logCommandResult('git', 0, 'Success output', '');
+      
+      expect(console.log).toHaveBeenCalledWith(
+        '[2023-01-01T12:00:00.000Z] [INFO] Command succeeded: git'
+      );
+      expect(console.log).toHaveBeenCalledWith(
+        '[2023-01-01T12:00:00.000Z] [DEBUG] stdout:\nSuccess output'
+      );
+    });
+
+    it('should log failed command result', () => {
+      logger.logCommandResult('git', 1, 'Error output', 'Error message');
+      
+      expect(console.log).toHaveBeenCalledWith(
+        '[2023-01-01T12:00:00.000Z] [ERROR] Command failed: git (exit code: 1)'
+      );
+      expect(console.log).toHaveBeenCalledWith(
+        '[2023-01-01T12:00:00.000Z] [ERROR] stderr:\nError message'
+      );
+      expect(console.log).toHaveBeenCalledWith(
+        '[2023-01-01T12:00:00.000Z] [DEBUG] stdout:\nError output'
+      );
+    });
+
+    it('should log command result with taskId', () => {
+      logger.logCommandResult('git', 0, 'Success output', '', 'task-123');
+      
+      expect(console.log).toHaveBeenCalledWith(
+        '[2023-01-01T12:00:00.000Z] [INFO] [task-123] Command succeeded: git'
+      );
+    });
+  });
+});

--- a/src/utils/__tests__/retry.test.ts
+++ b/src/utils/__tests__/retry.test.ts
@@ -1,0 +1,87 @@
+import { withRetry } from '../retry';
+
+describe('Retry Utility', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.spyOn(console, 'log').mockImplementation();
+    jest.spyOn(global, 'setTimeout').mockImplementation((callback) => {
+      if (typeof callback === 'function') {
+        callback();
+      }
+      return {} as NodeJS.Timeout;
+    });
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe('withRetry', () => {
+    it('should return result on successful operation', async () => {
+      const operation = jest.fn().mockResolvedValue('success');
+      const result = await withRetry(operation, 'test operation');
+
+      expect(result).toBe('success');
+      expect(operation).toHaveBeenCalledTimes(1);
+    });
+
+    it('should retry on failure and eventually succeed', async () => {
+      const operation = jest.fn()
+        .mockRejectedValueOnce(new Error('First failure'))
+        .mockRejectedValueOnce(new Error('Second failure'))
+        .mockResolvedValue('success');
+
+      const result = await withRetry(operation, 'test operation');
+
+      expect(result).toBe('success');
+      expect(operation).toHaveBeenCalledTimes(3);
+    });
+
+    it('should fail after max retries', async () => {
+      const operation = jest.fn().mockRejectedValue(new Error('Always fails'));
+
+      await expect(withRetry(operation, 'test operation', 2)).rejects.toThrow(
+        'test operation failed after 2 attempts: Always fails'
+      );
+      expect(operation).toHaveBeenCalledTimes(2);
+    });
+
+    it('should use default max retries of 3', async () => {
+      const operation = jest.fn().mockRejectedValue(new Error('Always fails'));
+
+      await expect(withRetry(operation, 'test operation')).rejects.toThrow(
+        'test operation failed after 3 attempts: Always fails'
+      );
+      expect(operation).toHaveBeenCalledTimes(3);
+    });
+
+    it('should log failures', async () => {
+      const operation = jest.fn()
+        .mockRejectedValueOnce(new Error('First failure'))
+        .mockResolvedValue('success');
+
+      await withRetry(operation, 'test operation');
+
+      expect(console.log).toHaveBeenCalledWith(
+        'test operation failed (attempt 1/3):',
+        expect.any(Error)
+      );
+    });
+
+    it('should handle different error types', async () => {
+      const operation = jest.fn().mockRejectedValue('string error');
+
+      await expect(withRetry(operation, 'test operation', 1)).rejects.toThrow(
+        'test operation failed after 1 attempts: undefined'
+      );
+    });
+
+    it('should handle undefined context', async () => {
+      const operation = jest.fn().mockRejectedValue(new Error('Test error'));
+
+      await expect(withRetry(operation, '', 1)).rejects.toThrow(
+        ' failed after 1 attempts: Test error'
+      );
+    });
+  });
+});

--- a/src/utils/__tests__/task-logging.test.ts
+++ b/src/utils/__tests__/task-logging.test.ts
@@ -1,0 +1,100 @@
+import { withTaskLogMessages } from '../task-logging';
+import { db } from '../../core/database';
+
+jest.mock('../../core/database', () => ({
+  db: {
+    addTaskLog: jest.fn(),
+  },
+}));
+
+const mockDb = db as jest.Mocked<typeof db>;
+
+describe('Task Logging', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('withTaskLogMessages', () => {
+    it('should log start and complete messages for successful action', async () => {
+      const mockAction = jest.fn().mockResolvedValue('success');
+      const options = {
+        taskId: 1,
+        startMessage: 'Starting task',
+        completeMessage: 'Task completed',
+        failureMessage: 'Task failed',
+      };
+
+      const result = await withTaskLogMessages(options, mockAction);
+
+      expect(result).toBe('success');
+      expect(mockDb.addTaskLog).toHaveBeenCalledWith({
+        task_id: 1,
+        level: 'info',
+        message: 'Starting task',
+      });
+      expect(mockDb.addTaskLog).toHaveBeenCalledWith({
+        task_id: 1,
+        level: 'info',
+        message: 'Task completed',
+      });
+      expect(mockAction).toHaveBeenCalled();
+    });
+
+    it('should log start and failure messages for failed action', async () => {
+      const error = new Error('Test error');
+      const mockAction = jest.fn().mockRejectedValue(error);
+      const options = {
+        taskId: 2,
+        startMessage: 'Starting task',
+        completeMessage: 'Task completed',
+        failureMessage: 'Task failed',
+      };
+
+      await expect(withTaskLogMessages(options, mockAction)).rejects.toThrow('Test error');
+
+      expect(mockDb.addTaskLog).toHaveBeenCalledWith({
+        task_id: 2,
+        level: 'info',
+        message: 'Starting task',
+      });
+      expect(mockDb.addTaskLog).toHaveBeenCalledWith({
+        task_id: 2,
+        level: 'error',
+        message: 'Task failed: Test error',
+      });
+      expect(mockAction).toHaveBeenCalled();
+    });
+
+    it('should handle non-Error objects', async () => {
+      const mockAction = jest.fn().mockRejectedValue('String error');
+      const options = {
+        taskId: 3,
+        startMessage: 'Starting task',
+        completeMessage: 'Task completed',
+        failureMessage: 'Task failed',
+      };
+
+      await expect(withTaskLogMessages(options, mockAction)).rejects.toBe('String error');
+
+      expect(mockDb.addTaskLog).toHaveBeenCalledWith({
+        task_id: 3,
+        level: 'error',
+        message: 'Task failed: String error',
+      });
+    });
+
+    it('should return the action result', async () => {
+      const mockAction = jest.fn().mockResolvedValue({ data: 'test' });
+      const options = {
+        taskId: 4,
+        startMessage: 'Starting task',
+        completeMessage: 'Task completed',
+        failureMessage: 'Task failed',
+      };
+
+      const result = await withTaskLogMessages(options, mockAction);
+
+      expect(result).toEqual({ data: 'test' });
+    });
+  });
+});


### PR DESCRIPTION
### Summary

This pull request introduces unit tests for each TypeScript file and configures Jest to facilitate testing. The additions include setting up Jest configuration and mocking commonly used modules.

### Changes

- **Jest Configuration**: Added a `jest.config.js` file to configure the Jest environment. The configuration specifies TypeScript preset (`ts-jest`), node as the test environment, and defines the directory and pattern for test files. It also specifies files to collect coverage from and excludes certain files from coverage.

- **Setup File**: Introduced `setup.ts` in the `__tests__` directory to mock commonly used modules such as `fs`, `better-sqlite3`, `execa`, `simple-git`, and `openai` to streamline test operations without needing real implementations. 

### Testing

- **Test Environment**: Configured to use Jest with TypeScript integration via `ts-jest`.
- **Mocks**: Various mocks were set up for file system operations, database interactions, and external libraries to ensure tests run in isolation and are closer to unit-tests.