### PR TITLE
[DUCKLING] Truncate task descriptions to 500 chars in dashboard cards

### DIFF
--- a/public/js/dashboard.js
+++ b/public/js/dashboard.js
@@ -473,7 +473,7 @@ class Dashboard {
         
         <!-- Task Spec -->
         <div class="mb-3">
-          <p class="text-sm text-gray-700">${this.escapeHtml(task.description)}</p>
+          <p class="text-sm text-gray-700">${this.escapeHtml(task.description.length > 500 ? task.description.substring(0, 500) + '...' : task.description)}</p>
         </div>
         
         

--- a/src/core/github-cli-provider.ts
+++ b/src/core/github-cli-provider.ts
@@ -449,15 +449,10 @@ export class GitHubCLIProvider {
 
       // Use GraphQL to get recent PRs and filter out tool-generated ones
       const graphqlQuery = `query { viewer { pullRequests(first: 5, states: [OPEN, CLOSED, MERGED], orderBy: {field: CREATED_AT, direction: DESC}) { nodes { number title body author { login } } } } }`;
-      
+
       const result = await execCommand(
         'gh',
-        [
-          'api',
-          'graphql',
-          '-f',
-          `query=${graphqlQuery}`
-        ],
+        ['api', 'graphql', '-f', `query=${graphqlQuery}`],
         { cwd: repositoryPath }
       );
 
@@ -467,10 +462,12 @@ export class GitHubCLIProvider {
       }
 
       const graphqlResponse = JSON.parse(result.stdout);
-      
+
       // Filter out PRs created by this tool (those with the prefix)
       const allPRs = graphqlResponse.data.viewer.pullRequests.nodes;
-      const recentPRs = allPRs.filter((pr: any) => !pr.title.startsWith(prTitlePrefix));
+      const recentPRs = allPRs.filter(
+        (pr: any) => !pr.title.startsWith(prTitlePrefix)
+      );
 
       // For each PR, try to get the diff as well
       const prsWithDiff = await Promise.all(
@@ -497,7 +494,9 @@ export class GitHubCLIProvider {
         })
       );
 
-      logger.info(`Found ${prsWithDiff.length} recent user PRs as examples (excluding tool-generated PRs)`);
+      logger.info(
+        `Found ${prsWithDiff.length} recent user PRs as examples (excluding tool-generated PRs)`
+      );
       return prsWithDiff;
     } catch (error) {
       logger.warn(`Failed to fetch recent PRs: ${error}`);

--- a/src/core/prompts.ts
+++ b/src/core/prompts.ts
@@ -44,9 +44,12 @@ ${pr.body}
       }
     });
 
-    if (examplesText === `Here are examples of recent PR descriptions from this repository (ONLY the description content, use these as style guides):
+    if (
+      examplesText ===
+      `Here are examples of recent PR descriptions from this repository (ONLY the description content, use these as style guides):
 
-`) {
+`
+    ) {
       examplesText = ''; // No examples found
     }
   }


### PR DESCRIPTION
### Summary

- Implement display logic in the task cards on the dashboard to show only the first 500 characters of the task description, appending "..." if the description exceeds this length.
- Ensure that the entire task description remains visible and unaltered in the task details view.

### Modifications

- Updated `dashboard.js` to limit the display of task descriptions in task cards to 500 characters and append "..." when necessary.
- Made syntax and formatting improvements in `github-cli-provider.ts` for readability without altering the logic.