### PR TITLE
[DUCKLING] Clarify non-interactive review prompt in CoreEngine's code generation task

### DIFF
--- a/src/core/engine.ts
+++ b/src/core/engine.ts
@@ -619,7 +619,7 @@ export class CoreEngine extends EventEmitter {
           // Generate response/fixes based on all comments at once
           const output = await this.codingManager.generateCode(
             task.coding_tool,
-            `Original task: ${task.description}\n\nPR review comments to address:\n\n${concatenatedComments}\n\nPlease address all the feedback above in one go.`,
+            `Original task: ${task.description}\n\nPR review comments to address:\n\n${concatenatedComments}\n\nAddress all the feedback above. Make all necessary code changes based on the review comments. Do not ask for clarification - analyze the available context and make the best decisions to resolve each comment. If a comment is ambiguous, choose the most logical interpretation based on the codebase patterns and the original task requirements.`,
             { taskId, repositoryPath: task.repository_path }
           );
 

--- a/src/core/github-cli-provider.ts
+++ b/src/core/github-cli-provider.ts
@@ -449,15 +449,10 @@ export class GitHubCLIProvider {
 
       // Use GraphQL to get recent PRs and filter out tool-generated ones
       const graphqlQuery = `query { viewer { pullRequests(first: 5, states: [OPEN, CLOSED, MERGED], orderBy: {field: CREATED_AT, direction: DESC}) { nodes { number title body author { login } } } } }`;
-      
+
       const result = await execCommand(
         'gh',
-        [
-          'api',
-          'graphql',
-          '-f',
-          `query=${graphqlQuery}`
-        ],
+        ['api', 'graphql', '-f', `query=${graphqlQuery}`],
         { cwd: repositoryPath }
       );
 
@@ -467,10 +462,12 @@ export class GitHubCLIProvider {
       }
 
       const graphqlResponse = JSON.parse(result.stdout);
-      
+
       // Filter out PRs created by this tool (those with the prefix)
       const allPRs = graphqlResponse.data.viewer.pullRequests.nodes;
-      const recentPRs = allPRs.filter((pr: any) => !pr.title.startsWith(prTitlePrefix));
+      const recentPRs = allPRs.filter(
+        (pr: any) => !pr.title.startsWith(prTitlePrefix)
+      );
 
       // For each PR, try to get the diff as well
       const prsWithDiff = await Promise.all(
@@ -497,7 +494,9 @@ export class GitHubCLIProvider {
         })
       );
 
-      logger.info(`Found ${prsWithDiff.length} recent user PRs as examples (excluding tool-generated PRs)`);
+      logger.info(
+        `Found ${prsWithDiff.length} recent user PRs as examples (excluding tool-generated PRs)`
+      );
       return prsWithDiff;
     } catch (error) {
       logger.warn(`Failed to fetch recent PRs: ${error}`);

--- a/src/core/prompts.ts
+++ b/src/core/prompts.ts
@@ -44,9 +44,12 @@ ${pr.body}
       }
     });
 
-    if (examplesText === `Here are examples of recent PR descriptions from this repository (ONLY the description content, use these as style guides):
+    if (
+      examplesText ===
+      `Here are examples of recent PR descriptions from this repository (ONLY the description content, use these as style guides):
 
-`) {
+`
+    ) {
       examplesText = ''; // No examples found
     }
   }


### PR DESCRIPTION
**Summary**: Updated the address review prompt in the code generation logic to clarify that it is non-interactive. Adjusted the instructions to resolve PR review comments by making decisions based on the available context without asking for clarification.

**Changes**: 
- Modified `generateCode` method in `src/core/engine.ts` to emphasize non-interactive review resolution.
- Streamlined the GraphQL query execution logic in `src/core/github-cli-provider.ts` by refining the command arguments formatting.