### PR TITLE
[DUCKLING] [PRVIS-XXXX] Add Jira API token setting on settings page and update endpoints

### DIFF
--- a/public/settings.html
+++ b/public/settings.html
@@ -147,6 +147,25 @@
           </div>
         </div>
 
+        <!-- Integration Settings -->
+        <div class="bg-white shadow rounded-lg">
+          <div class="px-6 py-4 border-b border-gray-200">
+            <h2 class="text-lg font-medium text-gray-900">Integration Settings</h2>
+            <p class="text-sm text-gray-500 mt-1">Configure external service integrations</p>
+          </div>
+          <div class="px-6 py-4 space-y-6">
+            <div>
+              <h3 class="text-sm font-medium text-gray-900 mb-3">Jira</h3>
+              <div>
+                <label for="jira-api-token" class="block text-sm font-medium text-gray-700">API Token</label>
+                <input type="password" id="jira-api-token" name="jiraApiToken"
+                  class="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-gray-400 focus:border-gray-400">
+                <p class="text-xs text-gray-500 mt-1"><strong>Optional:</strong> Jira API token for ticket integration. Leave empty if not using Jira features.</p>
+              </div>
+            </div>
+          </div>
+        </div>
+
         <!-- Task Configuration -->
         <div class="bg-white shadow rounded-lg">
           <div class="px-6 py-4 border-b border-gray-200">

--- a/src/api/routes.ts
+++ b/src/api/routes.ts
@@ -342,7 +342,7 @@ export function createRoutes(db: DatabaseManager, engine: CoreEngine): Router {
       const settingsObj = settings.getAll();
 
       // For password fields, return a special indicator if value exists
-      const secureFields = ['openaiApiKey'];
+      const secureFields = ['openaiApiKey', 'jiraApiToken'];
       const sanitizedSettings: Record<string, any> = {};
 
       for (const [key, value] of Object.entries(settingsObj)) {

--- a/src/core/settings-manager.ts
+++ b/src/core/settings-manager.ts
@@ -10,6 +10,7 @@ export interface SettingsDefaults {
   commentPrefix: string;
   maxRetries: number;
   openaiApiKey: string;
+  jiraApiToken: string;
   customPrompt: string;
 }
 
@@ -22,6 +23,7 @@ export class SettingsManager {
     commentPrefix: 'duckling',
     maxRetries: 3,
     openaiApiKey: '',
+    jiraApiToken: '',
     customPrompt: DEFAULT_CODING_PROMPT,
   };
 


### PR DESCRIPTION
**Summary**: Add a new optional setting for a Jira API token on the settings page, store it in the database, and update the settings endpoints to handle this new entry.

**Changes**:
- Implemented a section for Integration Settings on the settings page.
- Added an input field for the Jira API token, marked as optional.
- Updated the settings endpoints to handle and store the Jira API token.