### PR TITLE
[DUCKLING] [PRVIS-XXXX] Check user name consistency with GitHub CLI in comments

### DIFF
--- a/src/core/github-cli-provider.ts
+++ b/src/core/github-cli-provider.ts
@@ -19,6 +19,7 @@ export class GitHubCLIProvider {
   private repoOwner: string = '';
   private repoName: string = '';
   private currentRepoPath: string = '';
+  private cachedCurrentUser: string | null = null;
 
   constructor(
     db: DatabaseManager,
@@ -42,6 +43,34 @@ export class GitHubCLIProvider {
     } catch (error) {
       throw new Error(`Failed to get repository information: ${error}`);
     }
+  }
+
+  async getCurrentUser(repositoryPath?: string): Promise<string> {
+    // Return cached user if available
+    if (this.cachedCurrentUser) {
+      return this.cachedCurrentUser;
+    }
+
+    return await withRetry(
+      async () => {
+        const result = repositoryPath
+          ? await execCommand('gh', ['api', 'user', '--jq', '.login'], {
+              cwd: repositoryPath,
+            })
+          : await executeGitHubCLI('api user --jq .login');
+
+        if (repositoryPath && 'exitCode' in result && result.exitCode !== 0) {
+          throw new Error(`GitHub CLI command failed: ${result.stderr}`);
+        }
+
+        const username = result.stdout.trim();
+        this.cachedCurrentUser = username; // Cache the result
+        logger.info(`Current GitHub CLI user: ${username}`);
+        return username;
+      },
+      'Get current GitHub CLI user',
+      2
+    );
   }
 
   async getDefaultBranch(repositoryPath: string): Promise<string> {
@@ -250,6 +279,9 @@ export class GitHubCLIProvider {
     try {
       const commentPrefix = this.settings.get('commentPrefix');
 
+      // Get current authenticated user
+      const currentUser = await this.getCurrentUser(repositoryPath);
+
       // Get all comment types (reviews, review comments, and PR comments)
       const { reviewComments, prComments } = await this.getAllCommentsSeparated(
         prNumber,
@@ -278,6 +310,7 @@ export class GitHubCLIProvider {
       return processAllComments(prCommentData, reviewCommentData, {
         commentPrefix,
         lastCommitTimestamp,
+        currentUser,
       });
     } catch (error) {
       logger.error(

--- a/src/utils/comment-processor.ts
+++ b/src/utils/comment-processor.ts
@@ -18,16 +18,17 @@ export interface CommentData {
 export interface CommentProcessingOptions {
   commentPrefix: string;
   lastCommitTimestamp: string | null;
+  currentUser?: string;
 }
 
 /**
- * Filter comments based on prefix and timestamp
+ * Filter comments based on prefix, timestamp, and user authentication
  */
 export function filterComments(
   comments: CommentData[],
   options: CommentProcessingOptions
 ): CommentData[] {
-  const { commentPrefix, lastCommitTimestamp } = options;
+  const { commentPrefix, lastCommitTimestamp, currentUser } = options;
   const lastCommitDate = lastCommitTimestamp
     ? new Date(lastCommitTimestamp)
     : null;
@@ -41,13 +42,20 @@ export function filterComments(
       ? commentDate > lastCommitDate
       : true;
 
+    // Check if comment is from the current authenticated user
+    const isFromCurrentUser = currentUser
+      ? comment.user.login === currentUser
+      : true; // If no currentUser provided, don't filter by user
+
     logger.info(
       `Comment by ${comment.user.login}, ` +
+        `current user: ${currentUser || 'not specified'}, ` +
+        `user match: ${isFromCurrentUser}, ` +
         `time ${commentDate}, commit time ${lastCommitDate || 'null'}, ` +
         `starts with '${commentPrefix}': ${startsWithPrefix}`
     );
 
-    return startsWithPrefix && isNewerThanCommit;
+    return startsWithPrefix && isNewerThanCommit && isFromCurrentUser;
   });
 }
 


### PR DESCRIPTION
**Problem**: When finding comments to address, the current GitHub CLI user is not being verified to match the username from the GitHub CLI, leading to potential errors in comment handling.

**Solution**: Introduce a method to get the current GitHub CLI user and cache the result. Use this cached username to verify the user when handling comments.

**Jira ticket**: [TICKET-ID](https://canva.atlassian.net/browse/TICKET-ID)