### PR TITLE
[DUCKLING] [PRVIS-XXXX] Check user name in GH CLI when addressing comments

### DIFF
--- a/src/core/github-cli-provider.ts
+++ b/src/core/github-cli-provider.ts
@@ -250,6 +250,9 @@ export class GitHubCLIProvider {
     try {
       const commentPrefix = this.settings.get('commentPrefix');
 
+      // Get current user to filter out their own comments
+      const currentUser = await this.getCurrentUser(repositoryPath);
+
       // Get all comment types (reviews, review comments, and PR comments)
       const { reviewComments, prComments } = await this.getAllCommentsSeparated(
         prNumber,
@@ -278,6 +281,7 @@ export class GitHubCLIProvider {
       return processAllComments(prCommentData, reviewCommentData, {
         commentPrefix,
         lastCommitTimestamp,
+        currentUser,
       });
     } catch (error) {
       logger.error(
@@ -393,6 +397,34 @@ export class GitHubCLIProvider {
       repositoryPath
     );
     return [...reviewComments, ...prComments];
+  }
+
+  async getCurrentUser(repositoryPath: string): Promise<string | null> {
+    await this.ensureInitialized(repositoryPath);
+
+    return await withRetry(
+      async () => {
+        try {
+          const result = await execCommand(
+            'gh',
+            ['api', 'user', '--jq', '.login'],
+            { cwd: repositoryPath }
+          );
+          if (result.exitCode !== 0) {
+            throw new Error(`GitHub CLI command failed: ${result.stderr}`);
+          }
+          return result.stdout.trim();
+        } catch (error) {
+          logger.warn(
+            'Could not get current user from GitHub CLI:',
+            String(error)
+          );
+          return null;
+        }
+      },
+      'Get current user from GitHub CLI',
+      2
+    );
   }
 
   async getPRStatus(

--- a/src/utils/comment-processor.ts
+++ b/src/utils/comment-processor.ts
@@ -18,16 +18,17 @@ export interface CommentData {
 export interface CommentProcessingOptions {
   commentPrefix: string;
   lastCommitTimestamp: string | null;
+  currentUser?: string | null;
 }
 
 /**
- * Filter comments based on prefix and timestamp
+ * Filter comments based on prefix, timestamp, and user
  */
 export function filterComments(
   comments: CommentData[],
   options: CommentProcessingOptions
 ): CommentData[] {
-  const { commentPrefix, lastCommitTimestamp } = options;
+  const { commentPrefix, lastCommitTimestamp, currentUser } = options;
   const lastCommitDate = lastCommitTimestamp
     ? new Date(lastCommitTimestamp)
     : null;
@@ -41,13 +42,17 @@ export function filterComments(
       ? commentDate > lastCommitDate
       : true;
 
+    // Skip comments from the current user (bot's own comments)
+    const isFromCurrentUser = currentUser && comment.user.login === currentUser;
+
     logger.info(
       `Comment by ${comment.user.login}, ` +
         `time ${commentDate}, commit time ${lastCommitDate || 'null'}, ` +
-        `starts with '${commentPrefix}': ${startsWithPrefix}`
+        `starts with '${commentPrefix}': ${startsWithPrefix}, ` +
+        `from current user (${currentUser}): ${isFromCurrentUser}`
     );
 
-    return startsWithPrefix && isNewerThanCommit;
+    return startsWithPrefix && isNewerThanCommit && !isFromCurrentUser;
   });
 }
 


### PR DESCRIPTION
**Problem**: Comments are not adequately filtered to exclude those made by the user themselves when addressing comments.

**Solution**: Implement logic to retrieve the current user's username using the GitHub CLI and use it to filter out their own comments during processing.

**Summary**:
- Added `getCurrentUser` method to fetch the current username from the GitHub CLI.
- Integrated the current user into the comment filtering process in `processAllComments`.

**Jira ticket**: [PRVIS-3623](https://canva.atlassian.net/browse/PRVIS-3623)