### PR TITLE
[DUCKLING] Filter out pending reviews from GitHub CLI review processing

### DIFF
--- a/src/core/github-cli-provider.ts
+++ b/src/core/github-cli-provider.ts
@@ -332,8 +332,19 @@ export class GitHubCLIProvider {
     // 1. Get PR reviews (review bodies)
     const reviews = await this.getPRReviews(prNumber, repositoryPath);
 
+    // Filter out pending reviews and process only submitted ones
+    const submittedReviews = reviews.filter(
+      (review) => review.state !== 'PENDING'
+    );
+
+    if (reviews.length > submittedReviews.length) {
+      logger.info(
+        `Filtered out ${reviews.length - submittedReviews.length} pending review(s)`
+      );
+    }
+
     // Add review body comments and get their associated review comments
-    for (const review of reviews) {
+    for (const review of submittedReviews) {
       // Add the review body comment
       if (review.body && review.body.trim()) {
         reviewComments.push({


### PR DESCRIPTION
### Summary
This update modifies the process of handling pull request reviews by filtering out and ignoring pending reviews. Only submitted reviews are processed for PR review body comments and their associated review comments.

### Implementation
- Introduced a filtering mechanism to exclude reviews with a 'PENDING' state.
- Logged the number of filtered pending reviews for transparency.
- Updated the loop to process only the submitted reviews instead of all reviews.