### PR TITLE
[DUCKLING] Fix race condition in loading Jira repository on settings page

### DIFF
--- a/public/js/settings.js
+++ b/public/js/settings.js
@@ -6,10 +6,11 @@ class Settings {
     this.init();
   }
 
-  init() {
+  async init() {
     this.bindEvents();
-    this.loadSettings();
-    this.loadRepositories();
+    // Load settings and repositories sequentially to avoid race conditions
+    await this.loadSettings();
+    await this.loadRepositories();
   }
 
   bindEvents() {
@@ -78,7 +79,7 @@ class Settings {
     this.setSecureField('jira-api-key', settings.jiraApiKey);
     document.getElementById('jira-base-url').value = settings.jiraBaseUrl || '';
     document.getElementById('jira-jql-query').value = settings.jiraJqlQuery || '';
-    // Jira repository will be set after repositories are loaded
+    // Store Jira repository setting
     this.selectedJiraRepository = settings.jiraRepository || '';
 
     // Task configuration
@@ -95,6 +96,9 @@ class Settings {
 
     // Load precommit checks
     this.loadPrecommitChecks();
+    
+    // The Jira repository dropdown will be updated when repositories are loaded
+    // in the sequential loading process
   }
 
   async saveSettings() {


### PR DESCRIPTION
Summary:
- Modified the `init` function in `settings.js` to be asynchronous to address a potential race condition issue.
- Adjusted sequence of operations by loading settings and repositories sequentially using `await` to ensure proper loading order.
- Updated comments to reflect the changes in the loading process of Jira settings and repository list.

Motivation:
- The change aims to fix an issue where the Jira repository field appears empty in the settings page despite having a value, potentially caused by race conditions. By adjusting the load order, we aim to ensure the loaded data is correctly displayed.

Modification:
- Changed `init` function to `async` and utilized `await` for `loadSettings` and `loadRepositories` to enforce sequential loading.