### PR TITLE
[DUCKLING] Add skipUsernameCheck setting to filter comments by prefix only

### DIFF
--- a/public/js/settings.js
+++ b/public/js/settings.js
@@ -111,7 +111,6 @@ class Settings {
       settings[key] = value;
     }
 
-    // Handle checkbox fields that may not be present in FormData if unchecked
     settings.skipUsernameCheck = formData.has('skipUsernameCheck');
 
     // Convert numeric fields

--- a/public/js/settings.js
+++ b/public/js/settings.js
@@ -111,7 +111,8 @@ class Settings {
       settings[key] = value;
     }
 
-    settings.skipUsernameCheck = formData.has('skipUsernameCheck');
+    // Handle checkbox fields - parse the actual value instead of just checking presence
+    settings.skipUsernameCheck = formData.get('skipUsernameCheck') === 'on';
 
     // Convert numeric fields
     settings.maxRetries = parseInt(settings.maxRetries);

--- a/public/js/settings.js
+++ b/public/js/settings.js
@@ -97,7 +97,7 @@ class Settings {
 
     // Load precommit checks
     this.loadPrecommitChecks();
-    
+
     // The Jira repository dropdown will be updated when repositories are loaded
     // in the sequential loading process
   }
@@ -111,12 +111,11 @@ class Settings {
       settings[key] = value;
     }
 
-    // Handle checkbox fields - parse the actual value instead of just checking presence
-    settings.skipUsernameCheck = formData.get('skipUsernameCheck') === 'on';
+    // Convert bool
+    settings.skipUsernameCheck = settings.skipUsernameCheck === 'on';
 
     // Convert numeric fields
     settings.maxRetries = parseInt(settings.maxRetries);
-
 
     try {
       const response = await fetch('/api/settings', {

--- a/public/js/settings.js
+++ b/public/js/settings.js
@@ -89,6 +89,7 @@ class Settings {
     document.getElementById('commit-suffix').value = settings.commitSuffix || ' [quack]';
     document.getElementById('comment-prefix').value = settings.commentPrefix || 'duckling';
     document.getElementById('max-retries').value = settings.maxRetries || 3;
+    document.getElementById('skip-username-check').checked = settings.skipUsernameCheck || false;
 
 
     // Show configuration status
@@ -109,6 +110,9 @@ class Settings {
     for (const [key, value] of formData.entries()) {
       settings[key] = value;
     }
+
+    // Handle checkbox fields that may not be present in FormData if unchecked
+    settings.skipUsernameCheck = formData.has('skipUsernameCheck');
 
     // Convert numeric fields
     settings.maxRetries = parseInt(settings.maxRetries);

--- a/public/settings.html
+++ b/public/settings.html
@@ -199,7 +199,14 @@
               <p class="text-xs text-gray-500 mt-1">Maximum number of retry attempts when tasks fail due to transient
                 errors</p>
             </div>
-
+            <div>
+              <label class="flex items-center">
+                <input type="checkbox" id="skip-username-check" name="skipUsernameCheck" 
+                  class="mr-2 rounded border-gray-300 focus:outline-none focus:ring-gray-400 focus:border-gray-400">
+                <span class="text-sm font-medium text-gray-700">Skip Username Check</span>
+              </label>
+              <p class="text-xs text-gray-500 mt-1">When enabled, Duckling will process comments from any user, not just the authenticated user. This allows team members to interact with Duckling.</p>
+            </div>
 
           </div>
         </div>

--- a/public/settings.html
+++ b/public/settings.html
@@ -205,7 +205,7 @@
                   class="mr-2 rounded border-gray-300 focus:outline-none focus:ring-gray-400 focus:border-gray-400">
                 <span class="text-sm font-medium text-gray-700">Skip Username Check</span>
               </label>
-              <p class="text-xs text-gray-500 mt-1">When enabled, Duckling will process comments from any user, not just the authenticated user. This allows team members to interact with Duckling.</p>
+              <p class="text-xs text-gray-500 mt-1">When enabled, Duckling will process comments from any user, not just the authenticated user. This allows team members to interact with Duckling.<br><strong>Security Warning:</strong> By letting others interact with Duckling, they can technically directly interact with your development environment. Carefully consider who should be able to do this.</p>
             </div>
 
           </div>

--- a/src/core/github-cli-provider.ts
+++ b/src/core/github-cli-provider.ts
@@ -254,6 +254,7 @@ export class GitHubCLIProvider {
   ): Promise<string[]> {
     try {
       const commentPrefix = this.settings.get('commentPrefix');
+      const skipUsernameCheck = this.settings.get('skipUsernameCheck');
 
       // Get current user to filter out their own comments
       const currentUser = await this.getCurrentUser(repositoryPath);
@@ -287,6 +288,7 @@ export class GitHubCLIProvider {
         commentPrefix,
         lastCommitTimestamp,
         currentUser,
+        skipUsernameCheck,
       });
     } catch (error) {
       logger.error(

--- a/src/core/settings-manager.ts
+++ b/src/core/settings-manager.ts
@@ -16,6 +16,7 @@ interface SettingsDefaults {
   jiraBaseUrl: string;
   jiraRepository: string;
   customPrompt: string;
+  skipUsernameCheck: boolean;
 }
 
 export class SettingsManager {
@@ -33,6 +34,7 @@ export class SettingsManager {
     jiraBaseUrl: '',
     jiraRepository: '',
     customPrompt: DEFAULT_CODING_PROMPT,
+    skipUsernameCheck: false,
   };
 
   constructor(private db: DatabaseManager) {}
@@ -43,6 +45,10 @@ export class SettingsManager {
       // Handle number conversion
       if (typeof SettingsManager.DEFAULTS[key] === 'number') {
         return parseInt(setting.value) as SettingsDefaults[K];
+      }
+      // Handle boolean conversion
+      if (typeof SettingsManager.DEFAULTS[key] === 'boolean') {
+        return (setting.value === 'true') as SettingsDefaults[K];
       }
       return setting.value as SettingsDefaults[K];
     }

--- a/src/utils/comment-processor.ts
+++ b/src/utils/comment-processor.ts
@@ -19,6 +19,7 @@ interface CommentProcessingOptions {
   commentPrefix: string;
   lastCommitTimestamp: string | null;
   currentUser?: string | null;
+  skipUsernameCheck?: boolean;
 }
 
 /**
@@ -28,7 +29,8 @@ function filterComments(
   comments: CommentData[],
   options: CommentProcessingOptions
 ): CommentData[] {
-  const { commentPrefix, lastCommitTimestamp, currentUser } = options;
+  const { commentPrefix, lastCommitTimestamp, currentUser, skipUsernameCheck } =
+    options;
   const lastCommitDate = lastCommitTimestamp
     ? new Date(lastCommitTimestamp)
     : null;
@@ -42,14 +44,17 @@ function filterComments(
       ? commentDate > lastCommitDate
       : true;
 
-    // Only process comments from the current user (authorized user)
-    const isFromCurrentUser = currentUser && comment.user.login === currentUser;
+    // Check username only if skipUsernameCheck is false
+    const isFromCurrentUser = skipUsernameCheck
+      ? true
+      : currentUser && comment.user.login === currentUser;
 
     logger.info(
       `Comment by ${comment.user.login}, ` +
         `time ${commentDate}, commit time ${lastCommitDate || 'null'}, ` +
         `starts with '${commentPrefix}': ${startsWithPrefix}, ` +
-        `from current user (${currentUser}): ${isFromCurrentUser}`
+        `from current user (${currentUser}): ${isFromCurrentUser}, ` +
+        `skip username check: ${skipUsernameCheck}`
     );
 
     return startsWithPrefix && isNewerThanCommit && isFromCurrentUser;


### PR DESCRIPTION
### Summary

This pull request adds a new setting `skipUsernameCheck` to the system, with a default value of `false`. When enabled, this setting modifies the comment filtering behavior to process comments based only on their prefix, ignoring the username.

### Changes

- **UI**: Added a checkbox in the settings page (`public/settings.html`) for `skipUsernameCheck`.
- **JavaScript**: Updated `public/js/settings.js` to handle the `skipUsernameCheck` toggle state and update settings accordingly.
- **Logic**: Implemented the logic in the backend to accommodate this new setting, ensuring comments can be filtered solely by prefix when `skipUsernameCheck` is `true`. 

### Impact

This change allows users more flexibility in interacting with comments, enabling teams to bounce comments off the application seamlessly without username restrictions when the option is enabled.