### PR TITLE
[DUCKLING] Update task description with latest Jira ticket details on retry

### DIFF
--- a/src/core/engine.ts
+++ b/src/core/engine.ts
@@ -155,11 +155,51 @@ export class CoreEngine extends EventEmitter {
       throw new Error('Can only retry failed or cancelled tasks');
     }
 
+    // Check if this is a Jira ticket and refetch updated data
+    let updatedDescription = task.description;
+    if (this.jiraManager.isJiraTicket(task)) {
+      const jiraKey = this.jiraManager.getJiraKey(task);
+      if (jiraKey) {
+        this.db.addTaskLog({
+          task_id: taskId,
+          level: 'info',
+          message: `Refetching Jira ticket ${jiraKey} for updated information`,
+        });
+
+        try {
+          const updatedTicket = await this.jiraManager.getTicketByKey(jiraKey);
+          if (updatedTicket) {
+            // Reconstruct the task description with updated ticket data
+            updatedDescription = `Jira Ticket: ${updatedTicket.key}\nSummary: ${updatedTicket.summary}\n\n${updatedTicket.description}`;
+
+            this.db.addTaskLog({
+              task_id: taskId,
+              level: 'info',
+              message: `Updated task description with latest Jira ticket data (Status: ${updatedTicket.status})`,
+            });
+          } else {
+            this.db.addTaskLog({
+              task_id: taskId,
+              level: 'warn',
+              message: `Could not fetch updated Jira ticket ${jiraKey} - proceeding with existing description`,
+            });
+          }
+        } catch (error) {
+          this.db.addTaskLog({
+            task_id: taskId,
+            level: 'warn',
+            message: `Failed to fetch updated Jira ticket ${jiraKey}: ${error} - proceeding with existing description`,
+          });
+        }
+      }
+    }
+
     // Reset task to pending state and clear completion timestamp
     this.db.updateTask(taskId, {
       status: 'pending',
       current_stage: undefined,
       completed_at: undefined,
+      description: updatedDescription,
     });
 
     this.db.addTaskLog({

--- a/src/core/jira-manager.ts
+++ b/src/core/jira-manager.ts
@@ -17,26 +17,28 @@ interface JiraTicket {
 }
 
 interface JiraSearchResponse {
-  issues: Array<{
-    id: string;
-    key: string;
-    fields: {
-      summary: string;
-      description?: string;
-      status: {
-        name: string;
-      };
-      assignee?: {
-        displayName: string;
-        emailAddress: string;
-      };
-      created: string;
-      updated: string;
-    };
-  }>;
+  issues: Array<JiraIssueData>;
   total: number;
   isLast: boolean;
   nextPageToken?: string;
+}
+
+interface JiraIssueData {
+  id: string;
+  key: string;
+  fields: {
+    summary: string;
+    description?: string;
+    status: {
+      name: string;
+    };
+    assignee?: {
+      displayName: string;
+      emailAddress: string;
+    };
+    created: string;
+    updated: string;
+  };
 }
 
 export class JiraManager {
@@ -80,6 +82,72 @@ export class JiraManager {
     }
 
     return true;
+  }
+
+  /**
+   * Get a single Jira ticket by its key
+   */
+  async getTicketByKey(key: string): Promise<JiraTicket | null> {
+    if (!this.isConfigured()) {
+      return null;
+    }
+
+    const apiKey = this.settings.get('jiraApiKey');
+    const email = this.settings.get('jiraEmail');
+    const baseUrl = this.settings.get('jiraBaseUrl');
+
+    try {
+      return await withRetry(
+        async () => {
+          const authString = Buffer.from(`${email}:${apiKey}`).toString(
+            'base64'
+          );
+
+          const response = await fetch(
+            `${baseUrl}/rest/api/3/issue/${key}?fields=summary,description,status,assignee,created,updated`,
+            {
+              method: 'GET',
+              headers: {
+                Authorization: `Basic ${authString}`,
+                Accept: 'application/json',
+              },
+            }
+          );
+
+          if (!response.ok) {
+            if (response.status === 404) {
+              logger.warn(`Jira ticket ${key} not found`);
+              return null;
+            }
+            const errorText = await response.text();
+            throw new Error(
+              `Jira API error: ${response.status} ${response.statusText} - ${errorText}`
+            );
+          }
+
+          const issue = (await response.json()) as JiraIssueData;
+
+          const ticket: JiraTicket = {
+            id: issue.id,
+            key: issue.key,
+            summary: issue.fields.summary,
+            description: this.extractDescriptionText(issue.fields.description),
+            status: issue.fields.status.name,
+            assignee: issue.fields.assignee?.displayName,
+            created: issue.fields.created,
+            updated: issue.fields.updated,
+          };
+
+          logger.info(`Retrieved Jira ticket ${key}: ${ticket.summary}`);
+          return ticket;
+        },
+        'Jira API call for single ticket',
+        2
+      );
+    } catch (error) {
+      logger.error(`Failed to fetch Jira ticket ${key}: ${error}`);
+      return null;
+    }
   }
 
   /**


### PR DESCRIPTION
Summary:
This PR enhances the task retry mechanism by integrating Jira ticket data updates. When retrying a task that originates from a Jira support ticket, the system now checks for the latest ticket information, refetches it, and updates the task description.

Changes:
- Added logic to detect if a task is linked to a Jira ticket.
- Implemented functionality to extract the Jira key and refetch the ticket details.
- Updated the task description to reflect the current Jira ticket summary and description.
- Included logging to track the refetching process and outcomes.

Error Handling:
- Added error handling and logging for cases where Jira ticket refetching fails.