### PR TITLE
 Add CLI command to install Duckling as a systemd service with auto-start

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -36,6 +36,16 @@ duckling task list
 
 # Cancel a task
 duckling task cancel <taskId>
+
+# Install as systemd service (Linux only)
+duckling service install
+
+# Manage systemd service
+duckling service status
+duckling service start
+duckling service stop
+duckling service restart
+duckling service uninstall
 ```
 
 ## Architecture

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -10,6 +10,7 @@ import { PrecommitManager } from '../core/precommit-manager';
 import { OpenAIManager } from '../core/openai-manager';
 import { JiraManager } from '../core/jira-manager';
 import { CoreEngine } from '../core/engine';
+import { SystemdManager } from '../core/systemd-manager';
 import * as readline from 'readline';
 
 const program = new Command();
@@ -288,6 +289,128 @@ taskCmd
     }
   });
 
+// Service command group
+const serviceCmd = program
+  .command('service')
+  .description('Manage systemd service');
+
+// Install service command
+serviceCmd
+  .command('install')
+  .description('Install Duckling as a systemd service with auto-start')
+  .option('-p, --port <port>', 'Port to run the service on', '5050')
+  .action(async (options) => {
+    try {
+      const systemd = new SystemdManager();
+      const port = parseInt(options.port);
+
+      console.log('🚀 Installing Duckling as systemd service...\n');
+
+      await systemd.installService({ port });
+    } catch (error: any) {
+      console.error('❌ Failed to install service:', error.message);
+      process.exit(1);
+    }
+  });
+
+// Uninstall service command
+serviceCmd
+  .command('uninstall')
+  .description('Remove the systemd service')
+  .action(async () => {
+    try {
+      const systemd = new SystemdManager();
+
+      console.log('🗑️  Uninstalling Duckling systemd service...\n');
+
+      await systemd.uninstallService();
+    } catch (error: any) {
+      console.error('❌ Failed to uninstall service:', error.message);
+      process.exit(1);
+    }
+  });
+
+// Service status command
+serviceCmd
+  .command('status')
+  .description('Show systemd service status')
+  .action(async () => {
+    try {
+      const systemd = new SystemdManager();
+
+      console.log('🔧 Duckling Service Status\n');
+
+      const status = await systemd.getServiceStatus();
+
+      console.log(`Installed: ${status.installed ? '✅ Yes' : '❌ No'}`);
+
+      if (status.installed) {
+        console.log(`Active: ${status.active ? '✅ Running' : '❌ Stopped'}`);
+        console.log(
+          `Enabled: ${status.enabled ? '✅ Auto-start enabled' : '❌ Auto-start disabled'}`
+        );
+
+        if (status.status) {
+          console.log('\n📋 Detailed Status:');
+          console.log(status.status);
+        }
+
+        console.log('\n🔧 Management Commands:');
+        console.log('  Start:   systemctl --user start duckling');
+        console.log('  Stop:    systemctl --user stop duckling');
+        console.log('  Restart: systemctl --user restart duckling');
+        console.log('  Logs:    journalctl --user -u duckling -f');
+      } else {
+        console.log('\n💡 Install the service with: duckling service install');
+      }
+    } catch (error: any) {
+      console.error('❌ Failed to get service status:', error.message);
+      process.exit(1);
+    }
+  });
+
+// Start service command
+serviceCmd
+  .command('start')
+  .description('Start the systemd service')
+  .action(async () => {
+    try {
+      const systemd = new SystemdManager();
+      await systemd.startService();
+    } catch (error: any) {
+      console.error('❌ Failed to start service:', error.message);
+      process.exit(1);
+    }
+  });
+
+// Stop service command
+serviceCmd
+  .command('stop')
+  .description('Stop the systemd service')
+  .action(async () => {
+    try {
+      const systemd = new SystemdManager();
+      await systemd.stopService();
+    } catch (error: any) {
+      console.error('❌ Failed to stop service:', error.message);
+      process.exit(1);
+    }
+  });
+
+// Restart service command
+serviceCmd
+  .command('restart')
+  .description('Restart the systemd service')
+  .action(async () => {
+    try {
+      const systemd = new SystemdManager();
+      await systemd.restartService();
+    } catch (error: any) {
+      console.error('❌ Failed to restart service:', error.message);
+      process.exit(1);
+    }
+  });
+
 // Status command - show system status
 program
   .command('status')
@@ -327,6 +450,29 @@ program
         console.log(`   Awaiting Review: ${awaitingReviewTasks.length}`);
         console.log(`   Completed: ${completedTasks.length}`);
         console.log(`   Failed: ${failedTasks.length}`);
+
+        // Show systemd service status
+        try {
+          const systemd = new SystemdManager();
+          const serviceStatus = await systemd.getServiceStatus();
+
+          console.log('\n🔧 Service Status:');
+          console.log(
+            `   Installed: ${serviceStatus.installed ? '✅ Yes' : '❌ No'}`
+          );
+          if (serviceStatus.installed) {
+            console.log(
+              `   Active: ${serviceStatus.active ? '✅ Running' : '❌ Stopped'}`
+            );
+            console.log(
+              `   Auto-start: ${serviceStatus.enabled ? '✅ Enabled' : '❌ Disabled'}`
+            );
+          }
+        } catch {
+          console.log(
+            '\n🔧 Service Status: ❓ Unavailable (systemd not supported)'
+          );
+        }
       } else {
         console.log(
           '\n💡 Run "duckling start" and visit http://localhost:5050 to complete setup.'

--- a/src/core/systemd-manager.ts
+++ b/src/core/systemd-manager.ts
@@ -1,0 +1,340 @@
+import { execSync } from 'child_process';
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+
+interface SystemdServiceConfig {
+  serviceName: string;
+  description: string;
+  executablePath: string;
+  user: string;
+  workingDirectory: string;
+  environment?: Record<string, string>;
+  port?: number;
+}
+
+export class SystemdManager {
+  private readonly serviceName = 'duckling';
+
+  /**
+   * Install duckling as a systemd user service
+   */
+  async installService(options: { port?: number } = {}): Promise<void> {
+    const port = options.port || 5050;
+
+    // Check if we're on a Linux system with systemd
+    this.validateSystemd();
+
+    // Get current user and paths
+    const user = os.userInfo().username;
+    const executablePath = this.getExecutablePath();
+    const workingDirectory = process.cwd();
+
+    const config: SystemdServiceConfig = {
+      serviceName: this.serviceName,
+      description:
+        'Duckling - Automated coding tool that wraps CLI coding assistants',
+      executablePath,
+      user,
+      workingDirectory,
+      port,
+    };
+
+    // Create systemd service file
+    const serviceContent = this.generateServiceFile(config);
+    const servicePath = this.getUserServicePath();
+
+    // Ensure systemd user directory exists
+    const serviceDir = path.dirname(servicePath);
+    if (!fs.existsSync(serviceDir)) {
+      fs.mkdirSync(serviceDir, { recursive: true });
+    }
+
+    // Write service file
+    fs.writeFileSync(servicePath, serviceContent);
+    console.log(`📝 Service file created: ${servicePath}`);
+
+    // Enable lingering for the current user (allows user services to run without login)
+    try {
+      execSync(`sudo loginctl enable-linger ${user}`, { stdio: 'pipe' });
+      console.log(`✅ Enabled user lingering for ${user}`);
+    } catch (error) {
+      console.warn(
+        `⚠️ Failed to enable user lingering. Service may not start on boot without user login.`
+      );
+      console.warn(
+        `   You may need to run: sudo loginctl enable-linger ${user}`
+      );
+    }
+
+    // Reload systemd and enable the service
+    try {
+      execSync('systemctl --user daemon-reload', { stdio: 'pipe' });
+      console.log('🔄 Reloaded systemd daemon');
+
+      execSync(`systemctl --user enable ${this.serviceName}`, {
+        stdio: 'pipe',
+      });
+      console.log(`✅ Service enabled for auto-start`);
+
+      console.log(`\n🎉 Duckling systemd service installed successfully!`);
+      console.log(`\nService Management Commands:`);
+      console.log(`  Start:   systemctl --user start ${this.serviceName}`);
+      console.log(`  Stop:    systemctl --user stop ${this.serviceName}`);
+      console.log(`  Restart: systemctl --user restart ${this.serviceName}`);
+      console.log(`  Status:  systemctl --user status ${this.serviceName}`);
+      console.log(`  Logs:    journalctl --user -u ${this.serviceName} -f`);
+      console.log(`\nDuckling will be available at: http://localhost:${port}`);
+    } catch (error: any) {
+      throw new Error(`Failed to configure systemd service: ${error.message}`);
+    }
+  }
+
+  /**
+   * Uninstall the duckling systemd service
+   */
+  async uninstallService(): Promise<void> {
+    this.validateSystemd();
+
+    const servicePath = this.getUserServicePath();
+
+    if (!fs.existsSync(servicePath)) {
+      console.log('❌ Duckling systemd service is not installed');
+      return;
+    }
+
+    try {
+      // Stop the service if running
+      try {
+        execSync(`systemctl --user stop ${this.serviceName}`, {
+          stdio: 'pipe',
+        });
+        console.log('🛑 Stopped service');
+      } catch {
+        // Service might not be running, ignore
+      }
+
+      // Disable the service
+      try {
+        execSync(`systemctl --user disable ${this.serviceName}`, {
+          stdio: 'pipe',
+        });
+        console.log('❌ Disabled service auto-start');
+      } catch {
+        // Service might not be enabled, ignore
+      }
+
+      // Remove service file
+      fs.unlinkSync(servicePath);
+      console.log('🗑️  Removed service file');
+
+      // Reload systemd
+      execSync('systemctl --user daemon-reload', { stdio: 'pipe' });
+      console.log('🔄 Reloaded systemd daemon');
+
+      console.log(`\n✅ Duckling systemd service uninstalled successfully!`);
+    } catch (error: any) {
+      throw new Error(`Failed to uninstall systemd service: ${error.message}`);
+    }
+  }
+
+  /**
+   * Check if the service is installed
+   */
+  isServiceInstalled(): boolean {
+    return fs.existsSync(this.getUserServicePath());
+  }
+
+  /**
+   * Get service status
+   */
+  async getServiceStatus(): Promise<{
+    installed: boolean;
+    active: boolean;
+    enabled: boolean;
+    status?: string;
+  }> {
+    const installed = this.isServiceInstalled();
+
+    if (!installed) {
+      return { installed: false, active: false, enabled: false };
+    }
+
+    try {
+      // Check if service is active
+      let active = false;
+      try {
+        execSync(`systemctl --user is-active ${this.serviceName}`, {
+          stdio: 'pipe',
+        });
+        active = true;
+      } catch {
+        active = false;
+      }
+
+      // Check if service is enabled
+      let enabled = false;
+      try {
+        execSync(`systemctl --user is-enabled ${this.serviceName}`, {
+          stdio: 'pipe',
+        });
+        enabled = true;
+      } catch {
+        enabled = false;
+      }
+
+      // Get detailed status
+      let status = '';
+      try {
+        status = execSync(`systemctl --user status ${this.serviceName}`, {
+          encoding: 'utf-8',
+          stdio: 'pipe',
+        });
+      } catch (error: any) {
+        status = error.stdout || 'Status unavailable';
+      }
+
+      return { installed, active, enabled, status };
+    } catch (error) {
+      return { installed, active: false, enabled: false };
+    }
+  }
+
+  /**
+   * Start the service
+   */
+  async startService(): Promise<void> {
+    if (!this.isServiceInstalled()) {
+      throw new Error(
+        'Service is not installed. Run "duckling service install" first.'
+      );
+    }
+
+    try {
+      execSync(`systemctl --user start ${this.serviceName}`, { stdio: 'pipe' });
+      console.log('✅ Service started successfully');
+    } catch (error: any) {
+      throw new Error(`Failed to start service: ${error.message}`);
+    }
+  }
+
+  /**
+   * Stop the service
+   */
+  async stopService(): Promise<void> {
+    if (!this.isServiceInstalled()) {
+      throw new Error('Service is not installed');
+    }
+
+    try {
+      execSync(`systemctl --user stop ${this.serviceName}`, { stdio: 'pipe' });
+      console.log('🛑 Service stopped successfully');
+    } catch (error: any) {
+      throw new Error(`Failed to stop service: ${error.message}`);
+    }
+  }
+
+  /**
+   * Restart the service
+   */
+  async restartService(): Promise<void> {
+    if (!this.isServiceInstalled()) {
+      throw new Error('Service is not installed');
+    }
+
+    try {
+      execSync(`systemctl --user restart ${this.serviceName}`, {
+        stdio: 'pipe',
+      });
+      console.log('🔄 Service restarted successfully');
+    } catch (error: any) {
+      throw new Error(`Failed to restart service: ${error.message}`);
+    }
+  }
+
+  private validateSystemd(): void {
+    // Check if we're on Linux
+    if (os.platform() !== 'linux') {
+      throw new Error('Systemd services are only supported on Linux systems');
+    }
+
+    // Check if systemd is available
+    try {
+      execSync('which systemctl', { stdio: 'pipe' });
+    } catch {
+      throw new Error(
+        'systemctl not found. This system does not appear to have systemd installed.'
+      );
+    }
+  }
+
+  private getExecutablePath(): string {
+    // Try to find the duckling executable
+    try {
+      const result = execSync('which duckling', {
+        encoding: 'utf-8',
+        stdio: 'pipe',
+      });
+      return result.trim();
+    } catch {
+      // Fallback to the compiled version
+      const packageJson = JSON.parse(
+        fs.readFileSync(path.join(__dirname, '../../package.json'), 'utf-8')
+      );
+      const binPath = packageJson.bin?.duckling;
+      if (binPath) {
+        const absolutePath = path.resolve(process.cwd(), binPath);
+        if (fs.existsSync(absolutePath)) {
+          return absolutePath;
+        }
+      }
+
+      throw new Error(
+        'Could not find duckling executable. Make sure duckling is installed globally or run from the project directory.'
+      );
+    }
+  }
+
+  private getUserServicePath(): string {
+    const user = os.userInfo().username;
+    const serviceDir = `/home/${user}/.config/systemd/user`;
+    return path.join(serviceDir, `${this.serviceName}.service`);
+  }
+
+  private generateServiceFile(config: SystemdServiceConfig): string {
+    const envVars = config.environment
+      ? Object.entries(config.environment)
+          .map(([key, value]) => `Environment="${key}=${value}"`)
+          .join('\n')
+      : '';
+
+    return `[Unit]
+Description=${config.description}
+After=network.target
+
+[Service]
+Type=simple
+User=${config.user}
+WorkingDirectory=${config.workingDirectory}
+ExecStart=${config.executablePath} start${config.port ? ` --port ${config.port}` : ''}
+Restart=always
+RestartSec=10
+${envVars}
+
+# Standard output and error logging
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=${config.serviceName}
+
+# Security settings
+NoNewPrivileges=true
+PrivateTmp=true
+ProtectSystem=strict
+ProtectHome=read-only
+ReadWritePaths=/home/${config.user}/.duckling
+
+[Install]
+WantedBy=default.target
+`;
+  }
+}


### PR DESCRIPTION
### Summary
This pull request introduces a new CLI command to manage Duckling as a systemd service on Linux systems. The command includes functionality for installing, starting, stopping, restarting, and uninstalling the service.

### Features
- Added `duckling service install` to install Duckling as a systemd service with auto-start capability.
- Manage the service with additional commands: `status`, `start`, `stop`, `restart`, and `uninstall`. 

### Implementation
- A new `SystemdManager` is implemented to handle the systemd service operations.
- Commands are incorporated under a new `service` command group in the CLI.