### PR TITLE
[DUCKLING] Fix load more button stuck disabled on dashboard after initial use

### DIFF
--- a/public/js/dashboard.js
+++ b/public/js/dashboard.js
@@ -363,14 +363,15 @@ class Dashboard {
     if (this.isLoading || !this.hasMoreCompleted) return;
 
     this.isLoading = true;
-    this.completedPage++;
+    this.updateLoadMoreButton();
 
     try {
+      this.completedPage++;
       await this.loadCompletedTasks();
       this.renderTasks();
-      this.updateLoadMoreButton();
     } finally {
       this.isLoading = false;
+      this.updateLoadMoreButton();
     }
   }
 


### PR DESCRIPTION
### Summary
This pull request fixes an issue on the dashboard page where the "load more" button becomes permanently disabled after a single use.

### Changes
- Updated logic in `dashboard.js` to correctly manage the "load more" button state.
  - Moved `this.updateLoadMoreButton()` outside of conditional logic in `loadMoreTasks` to be called before and after loading tasks.