### PR TITLE
 Fix issue preventing empty PR prefix from being saved

### DIFF
--- a/public/js/settings.js
+++ b/public/js/settings.js
@@ -83,13 +83,13 @@ class Settings {
     this.selectedJiraRepository = settings.jiraRepository || '';
 
     // Task configuration
-    document.getElementById('custom-prompt').value = settings.customPrompt || '';
-    document.getElementById('branch-prefix').value = settings.branchPrefix || 'duckling-';
-    document.getElementById('pr-title-prefix').value = settings.prTitlePrefix || '[DUCKLING]';
-    document.getElementById('commit-suffix').value = settings.commitSuffix || ' [quack]';
-    document.getElementById('comment-prefix').value = settings.commentPrefix || 'duckling';
-    document.getElementById('max-retries').value = settings.maxRetries || 3;
-    document.getElementById('skip-username-check').checked = settings.skipUsernameCheck || false;
+    document.getElementById('custom-prompt').value = settings.customPrompt ?? '';
+    document.getElementById('branch-prefix').value = settings.branchPrefix ?? 'duckling-';
+    document.getElementById('pr-title-prefix').value = settings.prTitlePrefix ?? '[DUCKLING]';
+    document.getElementById('commit-suffix').value = settings.commitSuffix ?? ' [quack]';
+    document.getElementById('comment-prefix').value = settings.commentPrefix ?? 'duckling';
+    document.getElementById('max-retries').value = settings.maxRetries ?? 3;
+    document.getElementById('skip-username-check').checked = settings.skipUsernameCheck ?? false;
 
 
     // Show configuration status


### PR DESCRIPTION
### Summary
This pull request addresses an issue where the PR title prefix could not be saved as empty. The changes replace the logical OR (`||`) with the nullish coalescing operator (`??`) in the `settings.js` file, ensuring that a `null` or `undefined` value does not get overridden by default prefixes, allowing empty prefixes to be saved.